### PR TITLE
Fix: filter out past dates from weather forecast data

### DIFF
--- a/script.js
+++ b/script.js
@@ -315,7 +315,11 @@ function transformNwsData(data) {
     }
 
     // Now, build dailyData and hourlyData based on the days available in hourlyDays
-    const sortedDateKeys = Object.keys(hourlyDays).sort((a, b) => new Date(a) - new Date(b));
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+
+    let sortedDateKeys = Object.keys(hourlyDays).sort((a, b) => new Date(a) - new Date(b));
+    sortedDateKeys = sortedDateKeys.filter(dateKey => new Date(dateKey) >= today);
 
     sortedDateKeys.slice(0, 8).forEach(dateKey => {
         const dayHourlyData = hourlyDays[dateKey];
@@ -362,8 +366,13 @@ function transformOpenMeteoData(data) {
     const dailyData = [];
     const hourlyData = [];
 
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+
     data.daily.time.forEach((dateStr, i) => {
         const date = new Date(dateStr + 'T00:00');
+        if (date < today) return;
+
         dailyData.push({
             date,
             dayName: date.toLocaleDateString('en-US', { weekday: 'short' }),

--- a/transform_functions.js
+++ b/transform_functions.js
@@ -50,7 +50,14 @@ function transformNwsData(data) {
     }
 
     // Now process daily data, using the processed hourly data
-    Object.values(days).slice(0, 8).forEach(dayPeriods => {
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+
+    Object.values(days).filter(dayPeriods => {
+        const d = new Date(dayPeriods[0].startTime);
+        d.setHours(0, 0, 0, 0);
+        return d >= today;
+    }).slice(0, 8).forEach(dayPeriods => {
         const firstPeriod = dayPeriods[0];
         const date = new Date(firstPeriod.startTime);
         const dateKey = date.toLocaleDateString('en-US', { year: 'numeric', month: '2-digit', day: '2-digit' });
@@ -80,8 +87,13 @@ function transformOpenMeteoData(data) {
     const dailyData = [];
     const hourlyData = [];
 
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+
     data.daily.time.forEach((dateStr, i) => {
         const date = new Date(dateStr + 'T00:00');
+        if (date < today) return;
+
         dailyData.push({
             date,
             dayName: date.toLocaleDateString('en-US', { weekday: 'short' }),


### PR DESCRIPTION
Filtered out past dates in `script.js` and `transform_functions.js` logic for `transformNwsData` and `transformOpenMeteoData`.
Before populating the daily forecast array, any date older than "today" (using only the date parts: year, month, and day) is ignored so that the forecast properly displays today onwards instead of showing previous days.

---
*PR created automatically by Jules for task [1677829994410501403](https://jules.google.com/task/1677829994410501403) started by @coleca*