### PR TITLE
Feat: Switch to animated RainViewer API radar map

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This is a simple web application designed to help users determine if it's a good
 *   **Synchronized Hourly Charts**: Four interactive line charts display hourly wind speed, precipitation probability, temperature, and tide levels. The charts are synchronized, and sunrise/sunset are marked with icons directly on each chart's data line.
 *   **Human-Readable Location**: When using geolocation, the application uses reverse geocoding to display a user-friendly location name (e.g., "San Francisco, California") instead of just "Current Location."
 *   **Loading Indicator**: A loading spinner is displayed while weather data is being fetched to provide better user feedback.
-*   **Embedded Radar Map**: An interactive weather radar map from `meteoblue.com` is embedded at the bottom of the page.
+*   **Embedded Radar Map**: An interactive weather radar map from `RainViewer API` is embedded at the bottom of the page.
 
 ## Data Sources
 
@@ -19,7 +19,7 @@ This project utilizes several free data sources to provide a comprehensive weath
 *   **Open-Meteo API**: The primary source for the main weather forecast data (temperature, wind, etc.).
 *   **US National Weather Service API**: Provides severe weather alerts for US locations.
 *   **BigDataCloud API**: Used for free, fast reverse geocoding to convert coordinates into a human-readable location name.
-*   **meteoblue Weather Maps Widget**: Provides the embedded weather radar map.
+*   **RainViewer Animated Radar Maps**: Provides the embedded weather radar map.
 *   **weather-icons**: A font and CSS library used for the weather-themed icons in the application.
 
 ## Technologies Used

--- a/index.html
+++ b/index.html
@@ -57,6 +57,11 @@
         <p class="tide-disclaimer" style="display: none;">Tide data from nearest station. Verify with official charts.</p>
     </div>
     <div id="radar-map-container" class="content-width"></div>
+    <div id="radar-controls" class="content-width" style="display: none;">
+        <button id="radar-play-pause" class="radar-btn">Play</button>
+        <input type="range" id="radar-slider" min="0" max="10" value="10" step="1">
+        <span id="radar-time">Loading...</span>
+    </div>
     <div id="settings-modal" class="modal">
         <div class="modal-content">
             <span class="close-button">&times;</span>

--- a/script.js
+++ b/script.js
@@ -1,4 +1,9 @@
 let windChart, precipitationChart, temperatureChart, waveChart, tideChart, radarMap;
+// RainViewer variables
+let radarLayers = [];
+let radarTimestamps = [];
+let radarAnimationInterval = null;
+let currentRadarFrame = 0;
 // Store the raw data from the last successful API call
 let lastWeatherData = null;
 
@@ -613,11 +618,122 @@ function displayWeatherAlerts(alertData) {
 
 function displayRadarMap(lat, lon) {
     const radarContainer = document.getElementById('radar-map-container');
-    radarContainer.innerHTML = ''; radarContainer.style.height = '400px';
-    if (radarMap) radarMap.remove();
+    const controlsContainer = document.getElementById('radar-controls');
+    radarContainer.style.height = '400px';
+    controlsContainer.style.display = 'flex'; // show controls
+
+    // Stop any existing animation
+    if (radarAnimationInterval) {
+        clearInterval(radarAnimationInterval);
+        radarAnimationInterval = null;
+    }
+
+    if (radarMap) {
+        radarMap.remove();
+        radarLayers = [];
+        radarTimestamps = [];
+    }
+
     radarMap = L.map('radar-map-container').setView([lat, lon], 10);
-    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', { attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors' }).addTo(radarMap);
-    L.tileLayer.wms('https://opengeo.ncep.noaa.gov/geoserver/MRMS/wms', { layers: 'CREF', format: 'image/png', transparent: true, opacity: 0.8, time: new Date().toISOString(), attribution: 'NWS' }).addTo(radarMap);
+    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+        attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>'
+    }).addTo(radarMap);
+
+    // Fetch RainViewer API data
+    fetch('https://api.rainviewer.com/public/weather-maps.json')
+        .then(res => res.json())
+        .then(apiData => {
+            const pastFrames = apiData.radar.past;
+            radarTimestamps = pastFrames;
+
+            // Setup slider
+            const slider = document.getElementById('radar-slider');
+            slider.max = pastFrames.length - 1;
+            slider.value = pastFrames.length - 1;
+
+            // Load tile layers
+            pastFrames.forEach((frame, index) => {
+                const layer = L.tileLayer(`${apiData.host}${frame.path}/256/{z}/{x}/{y}/2/1_1.png`, {
+                    tileSize: 256,
+                    opacity: 0,
+                    zIndex: index
+                });
+                radarMap.addLayer(layer);
+                radarLayers.push(layer);
+            });
+
+            // Display latest frame
+            currentRadarFrame = pastFrames.length - 1;
+            showRadarFrame(currentRadarFrame);
+
+            setupRadarControls();
+        })
+        .catch(err => console.error("Error loading RainViewer API:", err));
+}
+
+function showRadarFrame(index) {
+    if (!radarLayers.length) return;
+
+    radarLayers.forEach((layer, i) => {
+        if (i === index) {
+            layer.setOpacity(0.8);
+        } else {
+            layer.setOpacity(0);
+        }
+    });
+
+    const timeSpan = document.getElementById('radar-time');
+    const slider = document.getElementById('radar-slider');
+
+    if (radarTimestamps[index]) {
+        const d = new Date(radarTimestamps[index].time * 1000);
+        timeSpan.innerText = d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+    }
+    slider.value = index;
+    currentRadarFrame = index;
+}
+
+function setupRadarControls() {
+    const playBtn = document.getElementById('radar-play-pause');
+    const slider = document.getElementById('radar-slider');
+
+    // Remove old event listeners if any
+    const newPlayBtn = playBtn.cloneNode(true);
+    playBtn.parentNode.replaceChild(newPlayBtn, playBtn);
+
+    const newSlider = slider.cloneNode(true);
+    slider.parentNode.replaceChild(newSlider, slider);
+
+    newPlayBtn.addEventListener('click', () => {
+        if (radarAnimationInterval) {
+            // Pause
+            clearInterval(radarAnimationInterval);
+            radarAnimationInterval = null;
+            newPlayBtn.innerText = 'Play';
+        } else {
+            // Play
+            if (currentRadarFrame >= radarTimestamps.length - 1) {
+                currentRadarFrame = 0;
+            }
+            newPlayBtn.innerText = 'Pause';
+            radarAnimationInterval = setInterval(() => {
+                currentRadarFrame++;
+                if (currentRadarFrame >= radarTimestamps.length) {
+                    currentRadarFrame = 0; // Loop back
+                }
+                showRadarFrame(currentRadarFrame);
+            }, 500); // 500ms per frame
+        }
+    });
+
+    newSlider.addEventListener('input', (e) => {
+        if (radarAnimationInterval) {
+            clearInterval(radarAnimationInterval);
+            radarAnimationInterval = null;
+            newPlayBtn.innerText = 'Play';
+        }
+        showRadarFrame(parseInt(e.target.value, 10));
+    });
 }
 
 // --- WEATHER LOGIC ---

--- a/style.css
+++ b/style.css
@@ -495,3 +495,44 @@ h1 {
     width: 95%;
     max-width: 1400px;
 }
+/* Radar Controls */
+#radar-controls {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 15px;
+    margin-top: 10px;
+    padding: 10px;
+    background-color: var(--card-bg);
+    border-radius: 8px;
+    box-shadow: 0 4px 6px var(--shadow-color);
+}
+
+.radar-btn {
+    padding: 8px 16px;
+    background-color: var(--primary-color);
+    color: white;
+    border: none;
+    border-radius: 5px;
+    cursor: pointer;
+    font-size: 1em;
+    font-weight: 500;
+    transition: background-color 0.3s;
+}
+
+.radar-btn:hover {
+    background-color: #0056b3;
+}
+
+#radar-slider {
+    flex-grow: 1;
+    cursor: pointer;
+}
+
+#radar-time {
+    font-size: 1em;
+    font-weight: bold;
+    color: var(--text-color);
+    min-width: 80px;
+    text-align: right;
+}


### PR DESCRIPTION
This commit replaces the existing weather radar implementation with the free RainViewer Animated Radar Maps API.

Changes include:
- Removing the NOAA WMS static tile layer.
- Fetching radar map data and timestamps from the RainViewer API (`weather-maps.json`).
- Implementing a time-lapse animation by fetching past 2-hours of radar layers and dynamically toggling their opacity.
- Adding playback controls (`Play/Pause`) and a timeline scrubber (`input type="range"`) to `index.html` below the map.
- Adjusting styles in `style.css` to handle the new playback controls.
- Updating `README.md` to indicate the new RainViewer API integration and remove outdated references to Meteoblue.

---
*PR created automatically by Jules for task [14893641480536852364](https://jules.google.com/task/14893641480536852364) started by @coleca*