### PR TITLE
Fix RainViewer radar map zoom error

### DIFF
--- a/script.js
+++ b/script.js
@@ -615,7 +615,8 @@ function displayRadarMap(lat, lon) {
 
     radarMap = L.map('radar-map-container').setView([lat, lon], 10);
     L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-        attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>'
+        attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>',
+        maxZoom: 18
     }).addTo(radarMap);
 
     // Fetch RainViewer API data
@@ -632,10 +633,11 @@ function displayRadarMap(lat, lon) {
 
             // Load tile layers
             pastFrames.forEach((frame, index) => {
-                const layer = L.tileLayer(`${apiData.host}${frame.path}/256/{z}/{x}/{y}/2/1_1.png`, {
+                const layer = L.tileLayer(`${apiData.host}${frame.path}/256/{z}/{x}/{y}/2/1_0.png`, {
                     tileSize: 256,
                     opacity: 0,
-                    zIndex: index
+                    zIndex: index,
+                    maxNativeZoom: 8
                 });
                 radarMap.addLayer(layer);
                 radarLayers.push(layer);


### PR DESCRIPTION
Fixes an issue where the RainViewer radar map would show a "zoomed in too much" error at zoom levels > 10. By setting `maxNativeZoom: 8` and using the `1_0.png` color scheme param on RainViewer tiles, Leaflet now scales available high-res tiles gracefully. OpenStreetMap base layer was also configured with `maxZoom: 18`.

---
*PR created automatically by Jules for task [17623033075706327504](https://jules.google.com/task/17623033075706327504) started by @coleca*