### PR TITLE
🧪 Add error path test for NOAA tide station list fetch failure

### DIFF
--- a/__tests__/weatherService.tide.test.js
+++ b/__tests__/weatherService.tide.test.js
@@ -114,4 +114,17 @@ describe('weatherService - Tide Data', () => {
     expect(localStorage.removeItem).toHaveBeenCalledWith('tideStations')
     expect(fetch).toHaveBeenCalledTimes(2)
   })
+
+  test('throws error if fetching station list fails', async () => {
+    // Mock the first fetch call to return a non-ok response
+    fetch.mockResolvedValueOnce({
+      ok: false,
+      statusText: 'Not Found',
+    })
+
+    await expect(getTideData(latitude, longitude)).rejects.toThrow('Failed to fetch NOAA tide station list.')
+
+    // fetch should have only been called once
+    expect(fetch).toHaveBeenCalledTimes(1)
+  })
 })


### PR DESCRIPTION
Added a test case in `__tests__/weatherService.tide.test.js` to cover the scenario where the initial fetch for the NOAA tide station list fails. The test mocks the fetch response with `ok: false` and verifies that `getTideData` throws the expected error "Failed to fetch NOAA tide station list.". This improvement increases the reliability and coverage of the weather service's tide lookup logic.

---
*PR created automatically by Jules for task [15957606338590154940](https://jules.google.com/task/15957606338590154940) started by @coleca*