### PR TITLE
🔒 [security fix] Add input validation for latitude and longitude in weatherService

### DIFF
--- a/__tests__/locationUtils.test.js
+++ b/__tests__/locationUtils.test.js
@@ -1,6 +1,33 @@
-import { getHaversineDistance } from '@/lib/locationUtils'
+import { getHaversineDistance, isValidCoordinate } from '@/lib/locationUtils'
 
 describe('locationUtils', () => {
+  describe('isValidCoordinate', () => {
+    test('should return true for valid coordinates', () => {
+      expect(isValidCoordinate(34.0522, -118.2437)).toBe(true)
+      expect(isValidCoordinate(0, 0)).toBe(true)
+      expect(isValidCoordinate(90, 180)).toBe(true)
+      expect(isValidCoordinate(-90, -180)).toBe(true)
+    })
+
+    test('should return false for invalid latitude', () => {
+      expect(isValidCoordinate(91, 0)).toBe(false)
+      expect(isValidCoordinate(-91, 0)).toBe(false)
+      expect(isValidCoordinate(NaN, 0)).toBe(false)
+      expect(isValidCoordinate(Infinity, 0)).toBe(false)
+      expect(isValidCoordinate('34', 0)).toBe(false)
+      expect(isValidCoordinate(null, 0)).toBe(false)
+    })
+
+    test('should return false for invalid longitude', () => {
+      expect(isValidCoordinate(0, 181)).toBe(false)
+      expect(isValidCoordinate(0, -181)).toBe(false)
+      expect(isValidCoordinate(0, NaN)).toBe(false)
+      expect(isValidCoordinate(0, Infinity)).toBe(false)
+      expect(isValidCoordinate(0, ' -118')).toBe(false)
+      expect(isValidCoordinate(0, undefined)).toBe(false)
+    })
+  })
+
   describe('getHaversineDistance', () => {
     test('should return 0 for the same coordinates', () => {
       const distance = getHaversineDistance(34.0522, -118.2437, 34.0522, -118.2437)

--- a/__tests__/weatherService.test.js
+++ b/__tests__/weatherService.test.js
@@ -126,5 +126,11 @@ describe('weatherService', () => {
         'NWS forecast API request failed: Internal Server Error'
       )
     })
+
+    test('throws an error if coordinates are invalid', async () => {
+      await expect(getNWSForecast(91, -118.2437)).rejects.toThrow('Invalid coordinates provided.')
+      await expect(getNWSForecast(34.0522, -181)).rejects.toThrow('Invalid coordinates provided.')
+      await expect(getNWSForecast('34', -118.2437)).rejects.toThrow('Invalid coordinates provided.')
+    })
   })
 })

--- a/__tests__/weatherService.tide.test.js
+++ b/__tests__/weatherService.tide.test.js
@@ -127,4 +127,10 @@ describe('weatherService - Tide Data', () => {
     // fetch should have only been called once
     expect(fetch).toHaveBeenCalledTimes(1)
   })
+
+  test('throws an error if coordinates are invalid', async () => {
+    await expect(getTideData(91, -118.2437)).rejects.toThrow('Invalid coordinates provided.')
+    await expect(getTideData(34.0522, -181)).rejects.toThrow('Invalid coordinates provided.')
+    await expect(getTideData(null, -118.2437)).rejects.toThrow('Invalid coordinates provided.')
+  })
 })

--- a/lib/locationUtils.js
+++ b/lib/locationUtils.js
@@ -7,6 +7,25 @@
  * @param {number} lon2 Longitude of the second point.
  * @returns {number} The distance in kilometers.
  */
+/**
+ * Validates whether the given latitude and longitude are valid coordinates.
+ * @param {number} latitude
+ * @param {number} longitude
+ * @returns {boolean} True if valid, false otherwise.
+ */
+export function isValidCoordinate(latitude, longitude) {
+  return (
+    typeof latitude === 'number' &&
+    Number.isFinite(latitude) &&
+    latitude >= -90 &&
+    latitude <= 90 &&
+    typeof longitude === 'number' &&
+    Number.isFinite(longitude) &&
+    longitude >= -180 &&
+    longitude <= 180
+  )
+}
+
 export function getHaversineDistance(lat1, lon1, lat2, lon2) {
   const R = 6371 // Radius of the Earth in kilometers
   const dLat = deg2rad(lat2 - lat1)

--- a/lib/weatherService.js
+++ b/lib/weatherService.js
@@ -4,6 +4,8 @@
 // This helps them identify the application making the request.
 const NWS_USER_AGENT = `CanIGoBoatingToday/1.0 (canigoboatingtoday.com, ${process.env.NEXT_PUBLIC_ADMIN_EMAIL || 'unspecified'})`
 
+import { getHaversineDistance, isValidCoordinate } from './locationUtils'
+
 /**
  * Fetches the weather forecast from the National Weather Service (NWS) API.
  * The NWS API requires two steps:
@@ -16,6 +18,10 @@ const NWS_USER_AGENT = `CanIGoBoatingToday/1.0 (canigoboatingtoday.com, ${proces
  * @throws {Error} If the API request fails at any step.
  */
 export async function getNWSForecast(latitude, longitude) {
+  if (!isValidCoordinate(latitude, longitude)) {
+    throw new Error('Invalid coordinates provided.')
+  }
+
   try {
     // Step 1: Get the gridpoint metadata
     const pointsUrl = `https://api.weather.gov/points/${latitude},${longitude}`
@@ -52,8 +58,6 @@ export async function getNWSForecast(latitude, longitude) {
   }
 }
 
-import { getHaversineDistance } from './locationUtils'
-
 const TIDE_STATIONS_CACHE_KEY = 'tideStations'
 const CACHE_DURATION_MS = 7 * 24 * 60 * 60 * 1000 // Cache for 7 days
 
@@ -66,6 +70,10 @@ const CACHE_DURATION_MS = 7 * 24 * 60 * 60 * 1000 // Cache for 7 days
  * @returns {Promise<object>} A promise that resolves to the tide prediction data.
  */
 export async function getTideData(latitude, longitude) {
+  if (!isValidCoordinate(latitude, longitude)) {
+    throw new Error('Invalid coordinates provided.')
+  }
+
   try {
     const closestStation = await findClosestTideStation(latitude, longitude)
 


### PR DESCRIPTION
The `getTideData` and `getNWSForecast` functions were missing validation for their `latitude` and `longitude` parameters. I have implemented a robust validation utility `isValidCoordinate` that checks if inputs are finite numbers within the valid geographic range. This utility is now applied at the entry point of both functions, throwing an error for invalid inputs. I also added comprehensive unit tests for the new validation logic.

---
*PR created automatically by Jules for task [15131330332963299471](https://jules.google.com/task/15131330332963299471) started by @coleca*