### PR TITLE
🔒 Fix client-side exposure of admin email in User-Agent

### DIFF
--- a/__tests__/weatherService.test.js
+++ b/__tests__/weatherService.test.js
@@ -59,7 +59,7 @@ describe('weatherService', () => {
         `https://api.weather.gov/points/${latitude},${longitude}`,
         {
           headers: {
-            'User-Agent': 'CanIGoBoatingToday/1.0 (canigoboatingtoday.com, unspecified)',
+            'User-Agent': 'CanIGoBoatingToday/1.0 (canigoboatingtoday.com, hello@canigoboatingtoday.com)',
           },
         }
       )
@@ -67,34 +67,11 @@ describe('weatherService', () => {
       // Verify fetch was called correctly for the second (forecast) request
       expect(fetch).toHaveBeenCalledWith(mockPointsData.properties.forecast, {
         headers: {
-          'User-Agent': 'CanIGoBoatingToday/1.0 (canigoboatingtoday.com, unspecified)',
+          'User-Agent': 'CanIGoBoatingToday/1.0 (canigoboatingtoday.com, hello@canigoboatingtoday.com)',
         },
       })
     })
 
-    test('uses NEXT_PUBLIC_ADMIN_EMAIL in User-Agent if provided', async () => {
-      process.env.NEXT_PUBLIC_ADMIN_EMAIL = 'test@example.com'
-      // We need to re-require the module to pick up the new environment variable
-      // because it's defined at the top level of weatherService.js
-      const { getNWSForecast: getNWSForecastWithEnv } = require('@/lib/weatherService')
-
-      fetch
-        .mockResolvedValueOnce({
-          ok: true,
-          json: async () => mockPointsData,
-        })
-        .mockResolvedValueOnce({
-          ok: true,
-          json: async () => mockForecastData,
-        })
-
-      await getNWSForecastWithEnv(latitude, longitude)
-
-      const expectedUserAgent = 'CanIGoBoatingToday/1.0 (canigoboatingtoday.com, test@example.com)'
-      expect(fetch).toHaveBeenCalledWith(expect.any(String), {
-        headers: { 'User-Agent': expectedUserAgent },
-      })
-    })
 
     test('throws an error if the points API request fails', async () => {
       // Simulate a failed response from the points API

--- a/lib/weatherService.js
+++ b/lib/weatherService.js
@@ -4,7 +4,7 @@ import { getHaversineDistance } from './locationUtils'
 
 // The NWS API requires a unique User-Agent header for all requests.
 // This helps them identify the application making the request.
-const NWS_USER_AGENT = `CanIGoBoatingToday/1.0 (canigoboatingtoday.com, ${process.env.NEXT_PUBLIC_ADMIN_EMAIL || 'unspecified'})`
+const NWS_USER_AGENT = `CanIGoBoatingToday/1.0 (canigoboatingtoday.com, hello@canigoboatingtoday.com)`
 
 import { getHaversineDistance, isValidCoordinate } from './locationUtils'
 


### PR DESCRIPTION
🎯 **What:** The `NEXT_PUBLIC_ADMIN_EMAIL` environment variable was being exposed in the client bundle via the `User-Agent` string for the NWS API.
⚠️ **Risk:** Any user inspecting the network requests or the JS bundle could extract the admin email address, potentially leading to spam or targeted attacks.
🛡️ **Solution:** Hardcoded a generic, non-sensitive email (`hello@canigoboatingtoday.com`) for the NWS `User-Agent` header, eliminating the need to use an environment variable on the client side.

---
*PR created automatically by Jules for task [2874291529557004168](https://jules.google.com/task/2874291529557004168) started by @coleca*