### PR TITLE
🧪 [testing improvement] Add test for unsupported geolocation

### DIFF
--- a/__tests__/WeatherDashboard.test.js
+++ b/__tests__/WeatherDashboard.test.js
@@ -93,4 +93,28 @@ describe('WeatherDashboard', () => {
       ).toBeInTheDocument()
     })
   })
+
+  test('displays an error message when geolocation is not supported', async () => {
+    const originalGeolocation = global.navigator.geolocation
+
+    // Simulate unsupported geolocation
+    Object.defineProperty(global.navigator, 'geolocation', {
+      value: undefined,
+      configurable: true,
+    })
+
+    render(<WeatherDashboard />)
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Error: Geolocation is not supported by this browser.')
+      ).toBeInTheDocument()
+    })
+
+    // Restore geolocation
+    Object.defineProperty(global.navigator, 'geolocation', {
+      value: originalGeolocation,
+      configurable: true,
+    })
+  })
 })


### PR DESCRIPTION
🎯 **What:** Added a missing test case in `WeatherDashboard.test.js` to address the gap in testing unsupported geolocation. The test overrides `global.navigator.geolocation` with `undefined` to simulate a browser without geolocation support and verifies that the correct error message is displayed.

📊 **Coverage:** Now the fallback logic for unsupported geolocation in `WeatherDashboard.js` is fully covered, ensuring the error state properly handles undefined geolocation.

✨ **Result:** Improved test coverage and reliability for geolocation error paths in the dashboard.

---
*PR created automatically by Jules for task [16170810267694293028](https://jules.google.com/task/16170810267694293028) started by @coleca*