### PR TITLE
fix: update package-lock.json and fix e2e test

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5672,6 +5672,15 @@
         "pnpm": ">=8"
       }
     },
+    "node_modules/chartjs-plugin-annotation": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/chartjs-plugin-annotation/-/chartjs-plugin-annotation-3.1.0.tgz",
+      "integrity": "sha512-EkAed6/ycXD/7n0ShrlT1T2Hm3acnbFhgkIEJLa0X+M6S16x0zwj1Fv4suv/2bwayCT3jGPdAtI9uLcAMToaQQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "chart.js": ">=4.0.0"
+      }
+    },
     "node_modules/chokidar": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",

--- a/tests/app.spec.js
+++ b/tests/app.spec.js
@@ -14,10 +14,9 @@ test.describe('Can I go boating today? App - E2E', () => {
     await expect(page.getByText(/Latitude: 34.0522/)).toBeVisible({ timeout: 15000 })
     await expect(page.getByText(/Longitude: -118.2437/)).toBeVisible()
 
-    // 2. Verify Current Conditions
-    // Check for the "Current Conditions" heading and that a forecast period (e.g., "Tonight") is visible.
-    await expect(page.getByRole('heading', { name: 'Current Conditions' })).toBeVisible()
-    await expect(page.getByText(/Tonight|Today|This Afternoon/)).toBeVisible()
+    // 2. Verify Day Forecasts
+    // Check that an abbreviated day header (e.g., "Thi" for This Afternoon, "Ton" for Tonight, etc.) is visible.
+    await expect(page.getByText(/Thi|Ton|Mon|Tue|Wed|Thu|Fri|Sat|Sun/).first()).toBeVisible()
 
     // 3. Verify Wave Forecast
     // Check that the wave forecast component has rendered and displays some value (even "N/A").


### PR DESCRIPTION
Fixes the github action deploy failure by syncing package-lock.json with package.json (adds missing `chartjs-plugin-annotation`). Also updates the e2e playwright test to check for the new day abbreviations (e.g., 'Thi', 'Ton') instead of the 'Current Conditions' heading, so tests pass with the new UI.

---
*PR created automatically by Jules for task [8174822024084310852](https://jules.google.com/task/8174822024084310852) started by @coleca*