### PR TITLE
Fix tide data and simplify chart layout

### DIFF
--- a/__tests__/weatherService.test.js
+++ b/__tests__/weatherService.test.js
@@ -1,4 +1,4 @@
-import { getNWSForecast } from '@/lib/weatherService'
+import { getNWSForecast, getTideData } from '@/lib/weatherService'
 
 // Mock the global fetch function before all tests
 global.fetch = jest.fn()
@@ -117,6 +117,42 @@ describe('weatherService', () => {
       await expect(getNWSForecast(91, -118.2437)).rejects.toThrow('Invalid latitude or longitude provided.')
       await expect(getNWSForecast(34.0522, -181)).rejects.toThrow('Invalid latitude or longitude provided.')
       await expect(getNWSForecast('34', -118.2437)).rejects.toThrow('Invalid latitude or longitude provided.')
+    })
+  })
+
+  describe('getTideData', () => {
+    test('falls back to the next nearby station when the closest station has no predictions', async () => {
+      fetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            stations: [
+              { id: '1', lat: 34.0522, lng: -118.2437, name: 'Closest' },
+              { id: '2', lat: 34.0622, lng: -118.2437, name: 'Backup' },
+            ],
+          }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ predictions: [] }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            predictions: [{ t: '2026-04-16 12:00', v: '2.4' }],
+          }),
+        })
+
+      const tideData = await getTideData(34.0522, -118.2437)
+
+      expect(tideData).toEqual({
+        predictions: [{ t: '2026-04-16 12:00', v: '2.4' }],
+      })
+      expect(fetch).toHaveBeenCalledTimes(3)
+    })
+
+    test('throws when coordinates are invalid', async () => {
+      await expect(getTideData(91, -118.2437)).rejects.toThrow('Invalid latitude or longitude provided.')
     })
   })
 })

--- a/components/WeatherDashboard.js
+++ b/components/WeatherDashboard.js
@@ -7,9 +7,9 @@ import { getNWSForecast, getTideData } from '@/lib/weatherService'
 import TideChart from './TideChart'
 import { extractHourlyDataForDay } from '@/lib/dataTransformers'
 import { WindChart, PrecipChart, TempChart, WaveChart } from './charts/HourlyCharts'
-import WaveForecast from './WaveForecast'
 import DynamicRadarMap from './DynamicRadarMap'
 import { formatWeekdayLabel, getDailyPeriods, getLocalDateKey } from '@/lib/forecastPeriods'
+import { parseWaveHeight } from '@/lib/forecastUtils'
 
 export default function WeatherDashboard() {
   const [location, setLocation] = useState(null)
@@ -48,6 +48,13 @@ export default function WeatherDashboard() {
 
     return closestPrediction?.v ?? null
   }, [activeChartHour, tideData?.predictions])
+
+  const activeOverlayLeft = useMemo(() => {
+    if (activeChartHour === null || activeChartHour === undefined) return null
+
+    const position = (activeChartHour / 23) * 100
+    return Math.min(92, Math.max(8, position))
+  }, [activeChartHour])
 
   useEffect(() => {
     if (!navigator.onLine) {
@@ -164,6 +171,20 @@ export default function WeatherDashboard() {
     return <div className="text-center p-8 text-xl">You are offline. Please check your internet connection.</div>
   }
 
+  const renderChartOverlay = (valueLabel) => {
+    if (!activeHourLabel || activeOverlayLeft === null) return null
+
+    return (
+      <div
+        className="pointer-events-none absolute top-12 z-10 -translate-x-1/2 rounded-xl border border-white/20 bg-[#245f8f]/90 px-3 py-2 text-center text-xs font-semibold text-white shadow-lg backdrop-blur-md"
+        style={{ left: `${activeOverlayLeft}%` }}
+      >
+        <div className="text-[10px] uppercase tracking-[0.12em] text-white/70">{activeHourLabel}</div>
+        <div className="mt-1 whitespace-nowrap text-sm">{valueLabel}</div>
+      </div>
+    )
+  }
+
   return (
       <div className="w-full flex flex-col items-center justify-start min-h-screen pt-2 pb-4 text-white sm:pt-4">
         {loading && (
@@ -215,6 +236,7 @@ export default function WeatherDashboard() {
               else if (shortForecastLower.includes('fog')) iconSrc = '/icons/fog.svg';
 
               const isSelected = index === selectedDayIndex;
+              const waveSummary = parseWaveHeight(period.detailedForecast)
 
               return (
               <div
@@ -230,24 +252,14 @@ export default function WeatherDashboard() {
                     </div>
                   </div>
 
-                  <div>
-                    <div className="sunrise-sunset text-[0.9em] mt-[15px] flex justify-around opacity-90">
-                        <div className="flex items-center gap-[8px]">
-                            <img src="/icons/sunrise.svg" alt="Sunrise" className="w-[20px] h-[20px]" style={{ filter: 'invert(1)' }}/>
-                            <span>6:00 AM</span>
-                        </div>
-                        <div className="flex items-center gap-[8px]">
-                            <img src="/icons/sunset.svg" alt="Sunset" className="w-[20px] h-[20px]" style={{ filter: 'invert(1)' }}/>
-                            <span>8:00 PM</span>
-                        </div>
+                  <div className="mt-4">
+                    <div className="flex flex-wrap justify-center gap-2 text-[0.85em] font-semibold">
+                      <span className="rounded-full bg-white/15 px-3 py-1">Wave {waveSummary}</span>
+                      <span className="rounded-full bg-white/15 px-3 py-1">{period.shortForecast}</span>
                     </div>
-
-                    <div className="boating-day text-[1em] font-semibold mt-[15px]">
-                       <div>MORN: <span className="yes text-[#28a745] font-bold ml-1">YES</span> <img src="/icons/sun.svg" className="w-4 h-4 inline-block ml-1" style={{ filter: 'invert(1)' }}/></div>
-                       <div className="mt-1">AFT: <span className="yes text-[#28a745] font-bold ml-1">YES</span> <img src="/icons/sun.svg" className="w-4 h-4 inline-block ml-1" style={{ filter: 'invert(1)' }}/></div>
+                    <div className="weather-description text-center mt-[10px] text-[0.9em] italic opacity-90">
+                      {period.detailedForecast}
                     </div>
-
-                    <div className="weather-description text-center mt-[10px] text-[0.9em] italic opacity-90">{period.shortForecast}</div>
                   </div>
               </div>
             )})}
@@ -258,23 +270,11 @@ export default function WeatherDashboard() {
           <div id="hourly-forecast-container" className="w-full max-w-[1400px] mt-[30px] px-3 sm:px-4">
             <div className="p-[18px] sm:p-[25px] bg-white/20 rounded-[15px] shadow-[0_8px_32px_0_rgba(31,38,135,0.37)] backdrop-blur-[4px]" style={{display: 'block'}}>
               <h2 id="hourly-forecast-day" className="text-[1.8em] text-center mb-[20px]">{dailyPeriods[selectedDayIndex]?.name}</h2>
-              <div className="p-4 bg-white/20 rounded-[10px] shadow text-center mb-4 border border-white/20">
-                  <p className="text-[1.1em]"><span className="font-semibold">{dailyPeriods[selectedDayIndex]?.name}:</span> {dailyPeriods[selectedDayIndex]?.detailedForecast}</p>
-              </div>
-
-              <div id="charts-container" className="mt-[20px] grid grid-cols-1 xl:grid-cols-2 gap-[15px]">
-                  <div className="chart-container relative h-[250px] bg-white/10 rounded-[12px] p-3">
-                    <WaveForecast forecast={dailyPeriods[selectedDayIndex]?.detailedForecast || ''} />
-                  </div>
-
+              <div id="charts-container" className="mt-[20px] flex flex-col gap-[15px]">
                   {hourlyData && (
                     <>
                       <div className="chart-container relative h-[250px] bg-white/10 rounded-[12px] p-3">
-                        {activeHourLabel && (
-                          <div className="absolute right-3 top-3 z-10 rounded-full bg-black/25 px-3 py-1 text-xs font-semibold">
-                            {activeHourLabel} {getHourlyValueForHour(hourlyData.wave) !== null ? `· ${getHourlyValueForHour(hourlyData.wave)} ft` : '· N/A'}
-                          </div>
-                        )}
+                        {renderChartOverlay(getHourlyValueForHour(hourlyData.wave) !== null ? `${getHourlyValueForHour(hourlyData.wave)} ft` : 'N/A')}
                         <WaveChart
                           waveData={hourlyData.wave}
                           labels={hourlyData.labels}
@@ -283,11 +283,7 @@ export default function WeatherDashboard() {
                         />
                       </div>
                       <div className="chart-container relative h-[250px] bg-white/10 rounded-[12px] p-3">
-                        {activeHourLabel && (
-                          <div className="absolute right-3 top-3 z-10 rounded-full bg-black/25 px-3 py-1 text-xs font-semibold">
-                            {activeHourLabel} {getHourlyValueForHour(hourlyData.temp) !== null ? `· ${getHourlyValueForHour(hourlyData.temp)}°F` : '· N/A'}
-                          </div>
-                        )}
+                        {renderChartOverlay(getHourlyValueForHour(hourlyData.temp) !== null ? `${getHourlyValueForHour(hourlyData.temp)}°F` : 'N/A')}
                         <TempChart
                           tempData={hourlyData.temp}
                           labels={hourlyData.labels}
@@ -296,11 +292,7 @@ export default function WeatherDashboard() {
                         />
                       </div>
                       <div className="chart-container relative h-[250px] bg-white/10 rounded-[12px] p-3">
-                        {activeHourLabel && (
-                          <div className="absolute right-3 top-3 z-10 rounded-full bg-black/25 px-3 py-1 text-xs font-semibold">
-                            {activeHourLabel} {getHourlyValueForHour(hourlyData.precip) !== null ? `· ${getHourlyValueForHour(hourlyData.precip)}%` : '· N/A'}
-                          </div>
-                        )}
+                        {renderChartOverlay(getHourlyValueForHour(hourlyData.precip) !== null ? `${getHourlyValueForHour(hourlyData.precip)}%` : 'N/A')}
                         <PrecipChart
                           precipData={hourlyData.precip}
                           labels={hourlyData.labels}
@@ -309,11 +301,7 @@ export default function WeatherDashboard() {
                         />
                       </div>
                       <div className="chart-container relative h-[250px] bg-white/10 rounded-[12px] p-3">
-                        {activeHourLabel && (
-                          <div className="absolute right-3 top-3 z-10 rounded-full bg-black/25 px-3 py-1 text-xs font-semibold">
-                            {activeHourLabel} {getHourlyValueForHour(hourlyData.wind) !== null ? `· ${getHourlyValueForHour(hourlyData.wind)} mph` : '· N/A'}
-                          </div>
-                        )}
+                        {renderChartOverlay(getHourlyValueForHour(hourlyData.wind) !== null ? `${getHourlyValueForHour(hourlyData.wind)} mph` : 'N/A')}
                         <WindChart
                           windData={hourlyData.wind}
                           labels={hourlyData.labels}
@@ -325,12 +313,8 @@ export default function WeatherDashboard() {
                   )}
 
                   {tideData && (
-                    <div className="chart-container relative h-[250px] bg-white/10 rounded-[12px] p-3 xl:col-span-2">
-                      {activeHourLabel && (
-                        <div className="absolute right-3 top-3 z-10 rounded-full bg-black/25 px-3 py-1 text-xs font-semibold">
-                          {activeHourLabel} {activeTideValue !== null ? `· ${activeTideValue} ft` : '· N/A'}
-                        </div>
-                      )}
+                    <div className="chart-container relative h-[250px] bg-white/10 rounded-[12px] p-3">
+                      {renderChartOverlay(activeTideValue !== null ? `${activeTideValue} ft` : 'N/A')}
                       <TideChart
                         tideData={tideData}
                         activeHour={activeChartHour}
@@ -340,7 +324,7 @@ export default function WeatherDashboard() {
                   )}
 
                   {tideStatus === 'loading' && (
-                    <div className="chart-container rounded-[12px] border border-white/15 bg-white/10 p-5 text-center xl:col-span-2">
+                    <div className="chart-container rounded-[12px] border border-white/15 bg-white/10 p-5 text-center">
                       Loading tide chart...
                     </div>
                   )}

--- a/lib/weatherService.js
+++ b/lib/weatherService.js
@@ -92,29 +92,29 @@ export async function getTideData(latitude, longitude) {
   }
 
   try {
-    const closestStation = await findClosestTideStation(latitude, longitude);
+    const nearbyStations = await findClosestTideStations(latitude, longitude);
 
-    if (!closestStation) {
+    if (!nearbyStations.length) {
       throw new Error("Could not find a nearby tide station.");
     }
 
-    // Get today's date in the required format (YYYYMMDD)
-    const today = new Date();
-    const dateString = `${today.getFullYear()}${(today.getMonth() + 1)
-      .toString()
-      .padStart(2, "0")}${today.getDate().toString().padStart(2, "0")}`;
+    // Some nearby stations in the metadata list do not actually return prediction data.
+    // Try the closest few in order until we find one with usable predictions.
+    for (const station of nearbyStations) {
+      const tideAPIUrl = `https://api.tidesandcurrents.noaa.gov/api/prod/datagetter?date=today&station=${station.id}&product=predictions&datum=MLLW&time_zone=lst_ldt&units=english&format=json&interval=h`
+      const tideResponse = await fetch(tideAPIUrl)
 
-    // Fetch the tide predictions for the closest station
-    const tideAPIUrl = `https://api.tidesandcurrents.noaa.gov/api/prod/datagetter?begin_date=${dateString}&end_date=${dateString}&station=${closestStation.id}&product=predictions&datum=MLLW&time_zone=lst_ldt&units=english&format=json`;
-    const tideResponse = await fetch(tideAPIUrl);
-    if (!tideResponse.ok) {
-      throw new Error(
-        `NOAA tide data API request failed: ${tideResponse.statusText}`,
-      );
+      if (!tideResponse.ok) {
+        continue
+      }
+
+      const tideData = await tideResponse.json()
+      if (Array.isArray(tideData.predictions) && tideData.predictions.length > 0) {
+        return tideData
+      }
     }
 
-    const tideData = await tideResponse.json();
-    return tideData;
+    throw new Error("Could not find tide predictions for nearby stations.");
   } catch (error) {
     logError("Error fetching tide data:", error);
     throw error;
@@ -129,7 +129,7 @@ export async function getTideData(latitude, longitude) {
  * @param {number} longitude
  * @returns {Promise<object>} The closest station object.
  */
-async function findClosestTideStation(latitude, longitude) {
+async function findClosestTideStations(latitude, longitude) {
   const cachedStations = getCachedTideStations();
 
   let stations = cachedStations;
@@ -144,30 +144,25 @@ async function findClosestTideStation(latitude, longitude) {
     cacheTideStations(stations);
   }
 
-  // Find the station with the minimum distance
-  let closestStation = null;
-  let minDistance = Infinity;
-
   // Pre-calculate values for the Haversine formula to optimize the loop
   const latRad = deg2rad(latitude);
   const lonRad = deg2rad(longitude);
   const cosLat = Math.cos(latRad);
 
-  for (const station of stations) {
-    const distance = getHaversineDistanceOptimized(
+  return stations
+    .map((station) => ({
+      station,
+      distance: getHaversineDistanceOptimized(
       latRad,
       lonRad,
       cosLat,
       station.lat,
       station.lng,
-    );
-    if (distance < minDistance) {
-      minDistance = distance;
-      closestStation = station;
-    }
-  }
-
-  return closestStation;
+    ),
+    }))
+    .sort((a, b) => a.distance - b.distance)
+    .slice(0, 5)
+    .map(({ station }) => station);
 }
 
 function getCachedTideStations() {

--- a/tests/app.spec.js
+++ b/tests/app.spec.js
@@ -93,14 +93,13 @@ test.describe('Can I go boating today? App - E2E', () => {
     // 2. Verify Day Forecasts
     await expect(page.getByRole('heading', { name: 'Thu', exact: true })).toBeVisible()
 
-    // 3. Verify Wave Forecast
-    // Check that the wave forecast component has rendered and displays some value (even "N/A").
-    await expect(page.getByRole('heading', { name: 'Wave Forecast' })).toBeVisible()
-    await expect(page.getByText(/Current Wave Height:/)).toBeVisible()
+    // 3. Verify the primary charts render and the old duplicate wave panel is gone
+    await expect(page.locator('#charts-container .chart-container')).toHaveCount(5)
+    await expect(page.locator('#charts-container canvas')).toHaveCount(5)
+    await expect(page.getByText('Wave Forecast')).toHaveCount(0)
 
     // 4. Verify Tide Chart
-    // The chart is rendered in a canvas. We'll check that its title is visible.
-    await expect(page.locator("canvas")).toBeVisible()
+    await expect(page.locator('#charts-container .chart-container').last().locator('canvas')).toBeVisible()
 
     // 5. Verify Radar Map
     // Check for the "Weather Radar" heading and that the map container is present.


### PR DESCRIPTION
## Summary
- fall back across nearby NOAA tide stations using the station-local current day
- remove the duplicate forecast and standalone wave cards, and stack charts vertically
- replace corner sync badges with shared in-chart value overlays and update tests

## Verification
- npm test -- --runInBand
- npm run build
- npm run test:e2e