### PR TITLE
Fix wave chart fallback and add current location button

### DIFF
--- a/__tests__/WeatherDashboard.test.js
+++ b/__tests__/WeatherDashboard.test.js
@@ -1,30 +1,344 @@
 import React from 'react'
-import { render, screen, waitFor } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import WeatherDashboard from '@/components/WeatherDashboard'
-import { getNWSForecast, getTideData } from '@/lib/weatherService'
+import { geocodeLocation, getNWSForecast, getTideData } from '@/lib/weatherService'
 
-jest.mock('@/lib/weatherService')
+jest.mock('@/lib/weatherService', () => ({
+  geocodeLocation: jest.fn(),
+  getNWSForecast: jest.fn(),
+  getTideData: jest.fn(),
+}))
 
-// Mock Next.js Image component
 jest.mock('next/image', () => ({ src, alt }) => <img src={src} alt={alt} />)
 
-// Mock the DynamicRadarMap
-jest.mock('@/components/DynamicRadarMap', () => () => <div data-testid="radar-map" />)
+jest.mock('@/components/DynamicRadarMap', () => ({ location }) => (
+  <div data-testid="radar-map">
+    Radar for {location.latitude}, {location.longitude}
+  </div>
+))
+
+jest.mock('@/components/TideChart', () => ({ onActiveHourChange }) => (
+  <button type="button" onClick={() => onActiveHourChange?.(18)}>
+    Today's Tide Predictions
+  </button>
+))
+
+jest.mock('@/components/charts/HourlyCharts', () => ({
+  WindChart: ({ onActiveHourChange }) => (
+    <button type="button" onClick={() => onActiveHourChange?.(6)}>
+      Wind Speed (mph)
+    </button>
+  ),
+  WaveChart: ({ onActiveHourChange }) => (
+    <button type="button" onClick={() => onActiveHourChange?.(7)}>
+      Wave Height (ft)
+    </button>
+  ),
+  TempChart: ({ onActiveHourChange }) => (
+    <button type="button" onClick={() => onActiveHourChange?.(8)}>
+      Temperature (°F)
+    </button>
+  ),
+  PrecipChart: ({ onActiveHourChange }) => (
+    <button type="button" onClick={() => onActiveHourChange?.(9)}>
+      Precipitation (%)
+    </button>
+  ),
+}))
+
+const DASHBOARD_CACHE_KEY = 'weatherDashboard:lastSuccessfulState'
+
+function buildWeatherData() {
+  return {
+    periods: [
+      {
+        name: 'Thursday',
+        isDaytime: true,
+        temperature: 72,
+        temperatureUnit: 'F',
+        shortForecast: 'Sunny',
+        detailedForecast: 'Sunny, with seas around 2 feet.',
+        startTime: '2026-04-16T06:00:00-04:00',
+      },
+      {
+        name: 'Thursday Night',
+        isDaytime: false,
+        temperature: 62,
+        temperatureUnit: 'F',
+        shortForecast: 'Mostly clear',
+        detailedForecast: 'Mostly clear, with seas around 1 foot.',
+        startTime: '2026-04-16T18:00:00-04:00',
+      },
+      {
+        name: 'Friday',
+        isDaytime: true,
+        temperature: 70,
+        temperatureUnit: 'F',
+        shortForecast: 'Rain showers',
+        detailedForecast: 'Rain likely. Waves 3 to 4 feet.',
+        startTime: '2026-04-17T06:00:00-04:00',
+      },
+    ],
+    gridData: {
+      windSpeed: {
+        values: [{ validTime: '2026-04-16T00:00:00-04:00/PT24H', value: 16 }],
+      },
+      waveHeight: {
+        values: [{ validTime: '2026-04-16T00:00:00-04:00/PT24H', value: 1 }],
+      },
+      temperature: {
+        values: [{ validTime: '2026-04-16T00:00:00-04:00/PT24H', value: 20 }],
+      },
+      probabilityOfPrecipitation: {
+        values: [{ validTime: '2026-04-16T00:00:00-04:00/PT24H', value: 25 }],
+      },
+    },
+  }
+}
+
+function buildTideData() {
+  return {
+    predictions: [
+      { t: '2026-04-16 00:00', v: '1.1' },
+      { t: '2026-04-16 06:00', v: '3.4' },
+      { t: '2026-04-16 18:00', v: '2.9' },
+    ],
+  }
+}
+
+let intersectionHandler = null
+
+function mockIntersectionObserver() {
+  global.IntersectionObserver = jest.fn((callback) => {
+    intersectionHandler = callback
+    return {
+      observe: jest.fn(),
+      disconnect: jest.fn(),
+      unobserve: jest.fn(),
+    }
+  })
+}
+
+function setNavigatorOnline(value) {
+  Object.defineProperty(window.navigator, 'onLine', {
+    configurable: true,
+    value,
+  })
+}
+
+function mockGeolocationSuccess(latitude = 34.0522, longitude = -118.2437) {
+  Object.defineProperty(window.navigator, 'geolocation', {
+    configurable: true,
+    value: {
+      getCurrentPosition: jest.fn((success) =>
+        success({
+          coords: { latitude, longitude },
+        })
+      ),
+    },
+  })
+}
+
+function mockGeolocationError() {
+  Object.defineProperty(window.navigator, 'geolocation', {
+    configurable: true,
+    value: {
+      getCurrentPosition: jest.fn((_success, error) => error(new Error('Permission denied'))),
+    },
+  })
+}
+
+function mockGeolocationIdle() {
+  Object.defineProperty(window.navigator, 'geolocation', {
+    configurable: true,
+    value: {
+      getCurrentPosition: jest.fn(),
+    },
+  })
+}
 
 describe('WeatherDashboard', () => {
   beforeEach(() => {
     jest.clearAllMocks()
-    global.IntersectionObserver = jest.fn(() => ({
-      observe: jest.fn(),
-      disconnect: jest.fn(),
-      unobserve: jest.fn(),
-    }))
+    localStorage.clear()
+    sessionStorage.clear()
+    setNavigatorOnline(true)
+    mockIntersectionObserver()
+    mockGeolocationIdle()
+    intersectionHandler = null
   })
 
   test('renders initial layout properly', () => {
     const { container } = render(<WeatherDashboard />)
+
     expect(screen.getByText('Can I go boating today?')).toBeInTheDocument()
     expect(screen.getByPlaceholderText('Enter a location')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Use current location' })).toBeInTheDocument()
     expect(container.querySelector('#loader-overlay')).toBeInTheDocument()
+  })
+
+  test('shows an offline message when the browser is offline', () => {
+    setNavigatorOnline(false)
+
+    render(<WeatherDashboard />)
+
+    expect(
+      screen.getByText('You are offline. Please check your internet connection.')
+    ).toBeInTheDocument()
+    expect(getNWSForecast).not.toHaveBeenCalled()
+  })
+
+  test('fetches forecast data from geolocation and loads the radar when scrolled into view', async () => {
+    mockGeolocationSuccess()
+    getNWSForecast.mockResolvedValue(buildWeatherData())
+    getTideData.mockResolvedValue(buildTideData())
+
+    render(<WeatherDashboard />)
+
+    await waitFor(() =>
+      expect(getNWSForecast).toHaveBeenCalledWith(34.0522, -118.2437)
+    )
+
+    expect(
+      screen.getByText('Latitude: 34.0522, Longitude: -118.2437')
+    ).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Thu' })).toBeInTheDocument()
+    expect(screen.getByText('Radar will load as you scroll near it.')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Wind Speed (mph)' }))
+    expect(screen.getAllByText('6 AM').length).toBeGreaterThan(0)
+    expect(screen.getByText('10 mph')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: "Today's Tide Predictions" }))
+    expect(screen.getAllByText('6 PM').length).toBeGreaterThan(0)
+    expect(screen.getByText('2.9 ft')).toBeInTheDocument()
+
+    intersectionHandler?.([{ isIntersecting: true }])
+
+    await waitFor(() => expect(screen.getByTestId('radar-map')).toBeInTheDocument())
+  })
+
+  test('falls back to New York when geolocation is denied', async () => {
+    mockGeolocationError()
+    getNWSForecast.mockResolvedValue(buildWeatherData())
+    getTideData.mockResolvedValue(buildTideData())
+
+    render(<WeatherDashboard />)
+
+    await waitFor(() =>
+      expect(getNWSForecast).toHaveBeenCalledWith(40.7128, -74.006)
+    )
+
+    expect(screen.getByText('New York')).toBeInTheDocument()
+  })
+
+  test('supports manual location searches', async () => {
+    mockGeolocationSuccess()
+    getNWSForecast.mockResolvedValue(buildWeatherData())
+    getTideData.mockResolvedValue(buildTideData())
+    geocodeLocation.mockResolvedValue({
+      name: 'Miami',
+      latitude: 25.7617,
+      longitude: -80.1918,
+    })
+
+    render(<WeatherDashboard />)
+
+    await waitFor(() =>
+      expect(getNWSForecast).toHaveBeenCalledWith(34.0522, -118.2437)
+    )
+
+    fireEvent.change(screen.getByPlaceholderText('Enter a location'), {
+      target: { value: 'Miami' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Get Weather' }))
+
+    await waitFor(() => expect(geocodeLocation).toHaveBeenCalledWith('Miami'))
+    await waitFor(() => expect(getNWSForecast).toHaveBeenLastCalledWith(25.7617, -80.1918))
+
+    expect(screen.getByText('Miami')).toBeInTheDocument()
+  })
+
+  test('supports refetching from the current-location button', async () => {
+    mockGeolocationSuccess(36.8508, -75.9779)
+    getNWSForecast.mockResolvedValue(buildWeatherData())
+    getTideData.mockResolvedValue(buildTideData())
+
+    render(<WeatherDashboard />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Use current location' }))
+
+    await waitFor(() => {
+      expect(getNWSForecast).toHaveBeenCalledWith(36.8508, -75.9779)
+    })
+  })
+
+  test('shows a weather error when the main forecast request fails', async () => {
+    mockGeolocationSuccess()
+    getNWSForecast.mockRejectedValue(new Error('Forecast is unavailable'))
+    getTideData.mockResolvedValue(buildTideData())
+
+    render(<WeatherDashboard />)
+
+    await waitFor(() =>
+      expect(
+        screen.getByText('Failed to fetch data: Forecast is unavailable')
+      ).toBeInTheDocument()
+    )
+
+    expect(screen.queryByText('Thursday')).not.toBeInTheDocument()
+  })
+
+  test('keeps the weather UI available when tide loading fails', async () => {
+    mockGeolocationSuccess()
+    getNWSForecast.mockResolvedValue(buildWeatherData())
+    getTideData.mockRejectedValue(new Error('Tide service unavailable'))
+
+    render(<WeatherDashboard />)
+
+    await waitFor(() =>
+      expect(screen.getByRole('heading', { name: 'Thu' })).toBeInTheDocument()
+    )
+
+    expect(screen.getByRole('button', { name: 'Wind Speed (mph)' })).toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: "Today's Tide Predictions" })
+    ).not.toBeInTheDocument()
+  })
+
+  test('hydrates from a recent cached dashboard state', () => {
+    mockGeolocationIdle()
+    localStorage.setItem(
+      DASHBOARD_CACHE_KEY,
+      JSON.stringify({
+        timestamp: Date.now(),
+        payload: {
+          location: { latitude: 32.7157, longitude: -117.1611 },
+          locationName: 'San Diego',
+          weatherData: buildWeatherData(),
+          tideData: buildTideData(),
+          tideStatus: 'ready',
+        },
+      })
+    )
+
+    render(<WeatherDashboard />)
+
+    expect(screen.getByText('San Diego')).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Thu' })).toBeInTheDocument()
+  })
+
+  test('falls back to forecast text for wave details when hourly wave grid data is missing', async () => {
+    mockGeolocationSuccess()
+    const weatherData = buildWeatherData()
+    weatherData.gridData.waveHeight.values = []
+    getNWSForecast.mockResolvedValue(weatherData)
+    getTideData.mockResolvedValue(buildTideData())
+
+    render(<WeatherDashboard />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Wave 2 ft')).toBeInTheDocument()
+    })
   })
 })

--- a/__tests__/forecastUtils.test.js
+++ b/__tests__/forecastUtils.test.js
@@ -1,4 +1,4 @@
-import { parseWaveHeight } from '@/lib/forecastUtils'
+import { parseWaveHeight, parseWaveHeightValue } from '@/lib/forecastUtils'
 
 describe('forecastUtils', () => {
   describe('parseWaveHeight', () => {
@@ -39,6 +39,20 @@ describe('forecastUtils', () => {
     test('should handle null or undefined input', () => {
       expect(parseWaveHeight(null)).toBe('N/A')
       expect(parseWaveHeight(undefined)).toBe('N/A')
+    })
+  })
+
+  describe('parseWaveHeightValue', () => {
+    test('returns a numeric height for a single wave value', () => {
+      expect(parseWaveHeightValue('Mostly sunny. Seas around 2 feet.')).toBe(2)
+    })
+
+    test('returns the midpoint for a wave range', () => {
+      expect(parseWaveHeightValue('Rain likely. Waves 3 to 5 feet.')).toBe(4)
+    })
+
+    test('returns null when no wave value can be parsed', () => {
+      expect(parseWaveHeightValue('No marine wave detail here.')).toBe(null)
     })
   })
 })

--- a/components/WeatherDashboard.js
+++ b/components/WeatherDashboard.js
@@ -9,7 +9,7 @@ import { extractHourlyDataForDay } from '@/lib/dataTransformers'
 import { WindChart, PrecipChart, TempChart, WaveChart } from './charts/HourlyCharts'
 import DynamicRadarMap from './DynamicRadarMap'
 import { formatWeekdayLabel, getDailyPeriods, getLocalDateKey } from '@/lib/forecastPeriods'
-import { parseWaveHeight } from '@/lib/forecastUtils'
+import { parseWaveHeight, parseWaveHeightValue } from '@/lib/forecastUtils'
 
 const DASHBOARD_CACHE_KEY = 'weatherDashboard:lastSuccessfulState'
 const DASHBOARD_CACHE_MAX_AGE_MS = 30 * 60 * 1000
@@ -30,6 +30,29 @@ export default function WeatherDashboard() {
 
   const clearActiveChartHour = () => {
     setActiveChartHour(null)
+  }
+
+  const loadCurrentLocation = () => {
+    if (!navigator.geolocation) {
+      return
+    }
+
+    setError(null)
+    setLoading(true)
+
+    navigator.geolocation.getCurrentPosition(
+      (position) => {
+        const { latitude, longitude } = position.coords
+        const resolvedLocationName = `Latitude: ${latitude.toFixed(4)}, Longitude: ${longitude.toFixed(4)}`
+        setLocation({ latitude, longitude })
+        setLocationName(resolvedLocationName)
+        fetchData(latitude, longitude, resolvedLocationName)
+      },
+      () => {
+        setError('Unable to get your current location.')
+        setLoading(false)
+      }
+    )
   }
 
   const getHourlyValueForHour = (series) => {
@@ -183,6 +206,22 @@ export default function WeatherDashboard() {
     return extractHourlyDataForDay(weatherData.gridData, selectedDateStr)
   }, [weatherData?.gridData, selectedDateStr])
 
+  const waveChartData = useMemo(() => {
+    if (!hourlyData) return null
+
+    const hasWaveSeriesData = hourlyData.wave.some((value) => value !== null && value !== undefined)
+    if (hasWaveSeriesData) {
+      return hourlyData.wave
+    }
+
+    const fallbackWaveValue = parseWaveHeightValue(dailyPeriods[selectedDayIndex]?.detailedForecast)
+    if (fallbackWaveValue === null) {
+      return hourlyData.wave
+    }
+
+    return hourlyData.wave.map(() => fallbackWaveValue)
+  }, [hourlyData, dailyPeriods, selectedDayIndex])
+
   const activeHourLabel = useMemo(() => {
     if (activeChartHour === null || activeChartHour === undefined || !hourlyData?.labels) return null
     return hourlyData.labels[activeChartHour] ?? null
@@ -275,14 +314,31 @@ export default function WeatherDashboard() {
 
         <div id="location-container" className="text-center mb-5 w-full max-w-[1400px] px-3 sm:px-4">
             <form id="location-form" onSubmit={handleLocationSubmit} className="flex flex-col sm:flex-row justify-center gap-2.5 mb-2.5">
-                <input
-                  type="text"
-                  id="location-input"
-                  placeholder="Enter a location"
-                  value={locationInput}
-                  onChange={(e) => setLocationInput(e.target.value)}
-                  className="p-[10px_15px] border border-white/50 rounded-[20px] bg-white/20 text-white text-[1em] w-full sm:w-[300px] placeholder:text-white/70"
-                />
+                <div className="relative w-full sm:w-[300px]">
+                  <input
+                    type="text"
+                    id="location-input"
+                    placeholder="Enter a location"
+                    value={locationInput}
+                    onChange={(e) => setLocationInput(e.target.value)}
+                    className="w-full rounded-[20px] border border-white/50 bg-white/20 py-[10px] pl-[15px] pr-[52px] text-[1em] text-white placeholder:text-white/70"
+                  />
+                  <button
+                    type="button"
+                    aria-label="Use current location"
+                    onClick={loadCurrentLocation}
+                    className="absolute right-1.5 top-1/2 flex h-9 w-9 -translate-y-1/2 items-center justify-center rounded-full bg-white/20 text-white transition-colors hover:bg-white/30"
+                  >
+                    <svg className="h-5 w-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                      <path d="M12 2v4" />
+                      <path d="M12 18v4" />
+                      <path d="M2 12h4" />
+                      <path d="M18 12h4" />
+                      <circle cx="12" cy="12" r="3" />
+                      <circle cx="12" cy="12" r="8" />
+                    </svg>
+                  </button>
+                </div>
                 <button type="submit" className="p-[10px_20px] border-none rounded-[20px] bg-white text-[#005f73] text-[1em] font-semibold cursor-pointer transition-colors hover:bg-[#f0f8ff] hover:text-[#003459]">Get Weather</button>
             </form>
             <p id="current-location" className="text-[1.1em] font-light opacity-90">{locationName}</p>
@@ -351,9 +407,9 @@ export default function WeatherDashboard() {
                         />
                       )}
                       {renderChartContainer(
-                        getHourlyValueForHour(hourlyData.wave) !== null ? `${getHourlyValueForHour(hourlyData.wave)} ft` : 'N/A',
+                        getHourlyValueForHour(waveChartData) !== null ? `${getHourlyValueForHour(waveChartData)} ft` : 'N/A',
                         <WaveChart
-                          waveData={hourlyData.wave}
+                          waveData={waveChartData}
                           labels={hourlyData.labels}
                           activeHour={activeChartHour}
                           onActiveHourChange={setActiveChartHour}

--- a/lib/forecastUtils.js
+++ b/lib/forecastUtils.js
@@ -25,3 +25,22 @@ export function parseWaveHeight(forecastString) {
 
   return 'N/A'
 }
+
+export function parseWaveHeightValue(forecastString) {
+  if (!forecastString) return null
+
+  const match = forecastString.match(WAVE_HEIGHT_REGEX)
+  if (!match) return null
+
+  const low = Number(match[1])
+  if (Number.isNaN(low)) return null
+
+  if (match[2]) {
+    const high = Number(match[2])
+    if (!Number.isNaN(high)) {
+      return Number(((low + high) / 2).toFixed(1))
+    }
+  }
+
+  return low
+}

--- a/tests/app.spec.js
+++ b/tests/app.spec.js
@@ -1,110 +1,242 @@
 // tests/app.spec.js
 import { test, expect } from '@playwright/test'
 
-test.describe('Can I go boating today? App - E2E', () => {
-  test('should load and display a complete weather forecast', async ({ page }) => {
-    const mockPointsData = {
-      properties: {
-        forecast: 'https://api.weather.gov/gridpoints/LOX/154,44/forecast',
-        forecastGridData: 'https://api.weather.gov/gridpoints/LOX/154,44',
-      },
+const losAngelesForecastUrl = 'https://api.weather.gov/gridpoints/LOX/154,44/forecast'
+const losAngelesGridUrl = 'https://api.weather.gov/gridpoints/LOX/154,44'
+const newYorkForecastUrl = 'https://api.weather.gov/gridpoints/OKX/33,35/forecast'
+const newYorkGridUrl = 'https://api.weather.gov/gridpoints/OKX/33,35'
+const miamiForecastUrl = 'https://api.weather.gov/gridpoints/MFL/110,50/forecast'
+const miamiGridUrl = 'https://api.weather.gov/gridpoints/MFL/110,50'
+
+async function mockForecastApis(page) {
+  await page.route('https://api.weather.gov/points/**', async (route) => {
+    const url = route.request().url()
+
+    if (url.includes('25.7617,-80.1918')) {
+      await route.fulfill({
+        json: {
+          properties: {
+            forecast: miamiForecastUrl,
+            forecastGridData: miamiGridUrl,
+          },
+        },
+      })
+      return
     }
 
-    const mockForecastData = {
-      properties: {
-        periods: [
-          {
-            name: 'Thursday',
-            isDaytime: true,
-            temperature: 72,
-            temperatureUnit: 'F',
-            shortForecast: 'Sunny',
-            detailedForecast: 'Sunny, with seas around 2 feet.',
-            startTime: '2026-04-16T09:00:00-07:00',
-            icon: 'https://api.weather.gov/icons/land/day/few?size=medium',
+    if (url.includes('40.7128,-74.006')) {
+      await route.fulfill({
+        json: {
+          properties: {
+            forecast: newYorkForecastUrl,
+            forecastGridData: newYorkGridUrl,
           },
-          {
-            name: 'Tonight',
-            isDaytime: false,
-            temperature: 60,
-            temperatureUnit: 'F',
-            shortForecast: 'Mostly clear',
-            detailedForecast: 'Mostly clear, with seas around 1 foot.',
-            startTime: '2026-04-16T18:00:00-07:00',
-            icon: 'https://api.weather.gov/icons/land/night/few?size=medium',
+        },
+      })
+      return
+    }
+
+    await route.fulfill({
+      json: {
+        properties: {
+          forecast: losAngelesForecastUrl,
+          forecastGridData: losAngelesGridUrl,
+        },
+      },
+    })
+  })
+
+  await page.route('https://api.weather.gov/gridpoints/**', async (route) => {
+    const url = route.request().url()
+
+    if (url === miamiForecastUrl) {
+      await route.fulfill({
+        json: {
+          properties: {
+            periods: [
+              {
+                name: 'Thursday',
+                isDaytime: true,
+                temperature: 84,
+                temperatureUnit: 'F',
+                shortForecast: 'Sunny',
+                detailedForecast: 'Sunny. Seas around 2 feet.',
+                startTime: '2026-04-16T09:00:00-04:00',
+                icon: 'https://api.weather.gov/icons/land/day/few?size=medium',
+              },
+              {
+                name: 'Tonight',
+                isDaytime: false,
+                temperature: 76,
+                temperatureUnit: 'F',
+                shortForecast: 'Mostly clear',
+                detailedForecast: 'Mostly clear. Seas around 1 foot.',
+                startTime: '2026-04-16T18:00:00-04:00',
+                icon: 'https://api.weather.gov/icons/land/night/few?size=medium',
+              },
+            ],
           },
+        },
+      })
+      return
+    }
+
+    if (url === newYorkForecastUrl) {
+      await route.fulfill({
+        json: {
+          properties: {
+            periods: [
+              {
+                name: 'Thursday',
+                isDaytime: true,
+                temperature: 62,
+                temperatureUnit: 'F',
+                shortForecast: 'Cloudy',
+                detailedForecast: 'Cloudy. Seas around 3 feet.',
+                startTime: '2026-04-16T09:00:00-04:00',
+                icon: 'https://api.weather.gov/icons/land/day/few?size=medium',
+              },
+              {
+                name: 'Tonight',
+                isDaytime: false,
+                temperature: 54,
+                temperatureUnit: 'F',
+                shortForecast: 'Mostly cloudy',
+                detailedForecast: 'Mostly cloudy. Seas around 2 feet.',
+                startTime: '2026-04-16T18:00:00-04:00',
+                icon: 'https://api.weather.gov/icons/land/night/few?size=medium',
+              },
+            ],
+          },
+        },
+      })
+      return
+    }
+
+    if (url === losAngelesForecastUrl) {
+      await route.fulfill({
+        json: {
+          properties: {
+            periods: [
+              {
+                name: 'Thursday',
+                isDaytime: true,
+                temperature: 72,
+                temperatureUnit: 'F',
+                shortForecast: 'Sunny',
+                detailedForecast: 'Sunny, with seas around 2 feet.',
+                startTime: '2026-04-16T09:00:00-07:00',
+                icon: 'https://api.weather.gov/icons/land/day/few?size=medium',
+              },
+              {
+                name: 'Tonight',
+                isDaytime: false,
+                temperature: 60,
+                temperatureUnit: 'F',
+                shortForecast: 'Mostly clear',
+                detailedForecast: 'Mostly clear, with seas around 1 foot.',
+                startTime: '2026-04-16T18:00:00-07:00',
+                icon: 'https://api.weather.gov/icons/land/night/few?size=medium',
+              },
+            ],
+          },
+        },
+      })
+      return
+    }
+
+    await route.fulfill({
+      json: {
+        properties: {
+          temperature: { values: [] },
+          windSpeed: { values: [] },
+          probabilityOfPrecipitation: { values: [] },
+          waveHeight: { values: [] },
+        },
+      },
+    })
+  })
+
+  await page.route(
+    'https://api.tidesandcurrents.noaa.gov/mdapi/prod/webapi/stations.json?type=tidepredictions',
+    async (route) => {
+      await route.fulfill({
+        json: {
+          stations: [{ id: '9410660', lat: 34.05, lng: -118.24, name: 'Los Angeles' }],
+        },
+      })
+    }
+  )
+
+  await page.route('https://api.tidesandcurrents.noaa.gov/api/prod/datagetter**', async (route) => {
+    await route.fulfill({
+      json: {
+        predictions: [
+          { t: '2026-04-16 00:00', v: '1.1' },
+          { t: '2026-04-16 06:00', v: '3.4' },
+          { t: '2026-04-16 12:00', v: '0.8' },
+          { t: '2026-04-16 18:00', v: '2.9' },
         ],
       },
-    }
+    })
+  })
 
-    const mockGridData = {
-      properties: {
-        temperature: { values: [] },
-        windSpeed: { values: [] },
-        probabilityOfPrecipitation: { values: [] },
-        waveHeight: { values: [] },
+  await page.route('https://geocoding-api.open-meteo.com/v1/search**', async (route) => {
+    await route.fulfill({
+      json: {
+        results: [{ name: 'Miami', latitude: 25.7617, longitude: -80.1918 }],
       },
-    }
-
-    const mockStations = {
-      stations: [{ id: '9410660', lat: 34.05, lng: -118.24, name: 'Los Angeles' }],
-    }
-
-    const mockTidePredictions = {
-      predictions: [
-        { t: '2026-04-16 00:00', v: '1.1' },
-        { t: '2026-04-16 06:00', v: '3.4' },
-        { t: '2026-04-16 12:00', v: '0.8' },
-        { t: '2026-04-16 18:00', v: '2.9' },
-      ],
-    }
-
-    await page.route('https://api.weather.gov/points/**', async (route) => {
-      await route.fulfill({ json: mockPointsData })
     })
+  })
+}
 
-    await page.route('https://api.weather.gov/gridpoints/LOX/154,44/forecast', async (route) => {
-      await route.fulfill({ json: mockForecastData })
-    })
+test.describe('Can I go boating today? App - E2E', () => {
+  test.beforeEach(async ({ page }) => {
+    await mockForecastApis(page)
+  })
 
-    await page.route('https://api.weather.gov/gridpoints/LOX/154,44', async (route) => {
-      await route.fulfill({ json: mockGridData })
-    })
-
-    await page.route('https://api.tidesandcurrents.noaa.gov/mdapi/prod/webapi/stations.json?type=tidepredictions', async (route) => {
-      await route.fulfill({ json: mockStations })
-    })
-
-    await page.route('https://api.tidesandcurrents.noaa.gov/api/prod/datagetter**', async (route) => {
-      await route.fulfill({ json: mockTidePredictions })
-    })
-
-    // Navigate to the home page
+  test('loads the app with geolocation and shows the main forecast experience', async ({ page }) => {
     await page.goto('/')
 
-    // Wait for the main heading to be visible, indicating the app has loaded
     await expect(page.locator('h1')).toHaveText('Can I go boating today?')
-
-    // 1. Verify Location Display
-    // Check that the latitude and longitude are displayed, confirming geolocation worked.
     await expect(page.getByText(/Latitude: 34.0522/)).toBeVisible({ timeout: 15000 })
     await expect(page.getByText(/Longitude: -118.2437/)).toBeVisible()
-
-    // 2. Verify Day Forecasts
-    await expect(page.getByRole('heading', { name: 'Thu', exact: true })).toBeVisible()
-
-    // 3. Verify the primary charts render and the old duplicate wave panel is gone
-    await expect(page.locator('#charts-container .chart-container')).toHaveCount(5)
-    await expect(page.locator('#charts-container canvas')).toHaveCount(5)
+    await expect(page.locator('#charts-container .chart-container')).toHaveCount(5, { timeout: 15000 })
+    await expect(page.getByText('Wave 2 ft').first()).toBeVisible()
     await expect(page.getByText('Wave Forecast')).toHaveCount(0)
+    await expect(page.locator('#radar-map-container')).toBeVisible()
 
-    // 4. Verify Tide Chart
-    await expect(page.locator('#charts-container .chart-container').last().locator('canvas')).toBeVisible()
-
-    // 5. Verify Radar Map
-    // Check for the "Weather Radar" heading and that the map container is present.
+    await page.locator('#radar-map-container').scrollIntoViewIfNeeded()
     await expect(page.getByRole('heading', { name: 'Weather Radar' })).toBeVisible()
-    // The map itself is in a specific container, let's check for the attribution text as a sign it's loaded.
     await expect(page.getByText(/OpenStreetMap/)).toBeVisible()
+  })
+
+  test('falls back to New York when browser geolocation fails', async ({ page }) => {
+    await page.addInitScript(() => {
+      Object.defineProperty(window.navigator, 'geolocation', {
+        configurable: true,
+        value: {
+          getCurrentPosition: (_success, error) => error(new Error('Denied')),
+        },
+      })
+    })
+
+    await page.goto('/')
+
+    await expect(page.getByText('New York')).toBeVisible({ timeout: 15000 })
+    await expect(page.locator('#charts-container .chart-container')).toHaveCount(5, { timeout: 15000 })
+  })
+
+  test('supports searching for a different location manually', async ({ page }) => {
+    await page.goto('/')
+
+    await expect(page.getByText(/Latitude: 34.0522/)).toBeVisible({ timeout: 15000 })
+
+    await page.getByPlaceholder('Enter a location').fill('Miami')
+    await page.getByRole('button', { name: 'Get Weather' }).click()
+
+    await expect(page.getByText('Miami')).toBeVisible({ timeout: 15000 })
+    await expect(page.locator('#charts-container .chart-container')).toHaveCount(5, { timeout: 15000 })
+    await expect(page.getByText('Wave 2 ft')).toBeVisible()
   })
 })


### PR DESCRIPTION
## Summary
- fall back to parsed marine forecast text when hourly wave grid data is missing so the wave chart no longer stays flat
- add an inline current-location button inside the location input with a standard target-style icon
- update the unit and end-to-end coverage for the new behavior

## Verification
- npm test -- --runInBand
- npm run build
- npm run test:e2e