### PR TITLE
[codex] Restore concise day cards and refresh stale NWS forecasts

### DIFF
--- a/__tests__/WeatherDashboard.test.js
+++ b/__tests__/WeatherDashboard.test.js
@@ -385,7 +385,7 @@ describe('WeatherDashboard', () => {
     expect(screen.getByRole('heading', { name: 'Thu' })).toBeInTheDocument()
   })
 
-  test('shows compact AM and PM decision indicators without duplicate forecast chips', async () => {
+  test('shows an old-style boating day card with hi low sun times and concise decisions', async () => {
     mockGeolocationSuccess()
     const weatherData = buildWeatherData()
     weatherData.gridData.waveHeight.values = []
@@ -399,10 +399,16 @@ describe('WeatherDashboard', () => {
       expect(screen.getByRole('heading', { name: 'Thu' })).toBeInTheDocument()
     })
 
-    expect(screen.getAllByLabelText('AM favorable').length).toBeGreaterThan(0)
-    expect(screen.getByLabelText('PM caution rain')).toBeInTheDocument()
+    expect(screen.getByText('72°F')).toBeInTheDocument()
+    expect(screen.getByText('62°F')).toBeInTheDocument()
+    expect(screen.getAllByText('Sunrise').length).toBeGreaterThan(0)
+    expect(screen.getAllByText('Sunset').length).toBeGreaterThan(0)
+    expect(screen.getByLabelText('morning yes')).toBeInTheDocument()
+    expect(screen.getByLabelText('afternoon no rain')).toBeInTheDocument()
+    expect(screen.getAllByText('MORN:').length).toBeGreaterThan(0)
+    expect(screen.getAllByText('AFT:').length).toBeGreaterThan(0)
     expect(screen.queryByText(/^Wave N\/A$/)).not.toBeInTheDocument()
-    expect(screen.queryByText(/^Sunny$/)).not.toBeInTheDocument()
+    expect(screen.getByText('Rain showers')).toBeInTheDocument()
   })
 
   test('does not render an alert banner when no marine alerts are active', async () => {

--- a/__tests__/forecastPeriods.test.js
+++ b/__tests__/forecastPeriods.test.js
@@ -1,4 +1,9 @@
-import { formatWeekdayLabel, getDailyPeriods, getLocalDateKey } from '@/lib/forecastPeriods'
+import {
+  formatWeekdayLabel,
+  getDailyForecastCards,
+  getDailyPeriods,
+  getLocalDateKey,
+} from '@/lib/forecastPeriods'
 
 describe('forecastPeriods', () => {
   test('getLocalDateKey returns a stable local YYYY-MM-DD key', () => {
@@ -22,5 +27,43 @@ describe('forecastPeriods', () => {
 
   test('formatWeekdayLabel returns short weekday names', () => {
     expect(formatWeekdayLabel('2026-04-16T09:00:00-07:00')).toBe('Thu')
+  })
+
+  test('getDailyForecastCards pairs daytime and nighttime periods for one decision card', () => {
+    const periods = [
+      {
+        name: 'Thursday',
+        isDaytime: true,
+        temperature: 72,
+        temperatureUnit: 'F',
+        shortForecast: 'Sunny',
+        detailedForecast: 'Sunny with light winds.',
+        startTime: '2026-04-16T06:00:00-07:00',
+      },
+      {
+        name: 'Thursday Night',
+        isDaytime: false,
+        temperature: 60,
+        temperatureUnit: 'F',
+        shortForecast: 'Mostly clear',
+        detailedForecast: 'Mostly clear overnight.',
+        startTime: '2026-04-16T19:45:00-07:00',
+      },
+    ]
+
+    expect(getDailyForecastCards(periods)).toEqual([
+      {
+        dateKey: '2026-04-16',
+        dayPeriod: periods[0],
+        nightPeriod: periods[1],
+        name: 'Thursday',
+        startTime: '2026-04-16T06:00:00-07:00',
+        shortForecast: 'Sunny',
+        detailedForecast: 'Sunny with light winds.',
+        temperatureHigh: 72,
+        temperatureLow: 60,
+        temperatureUnit: 'F',
+      },
+    ])
   })
 })

--- a/__tests__/weatherService.test.js
+++ b/__tests__/weatherService.test.js
@@ -135,6 +135,58 @@ describe('weatherService', () => {
       )
     })
 
+    test('refreshes stale point metadata and retries once when the forecast URL returns 404', async () => {
+      sessionStorage.setItem(
+        'points:34.05,-118.24',
+        JSON.stringify({
+          timestamp: Date.now(),
+          payload: {
+            properties: {
+              forecast: 'https://api.weather.gov/gridpoints/OLD/1,1/forecast',
+              forecastGridData: 'https://api.weather.gov/gridpoints/OLD/1,1',
+              radarStation: 'KOLD',
+            },
+          },
+        })
+      )
+
+      fetch
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 404,
+          statusText: 'Not Found',
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ properties: {} }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => mockPointsData,
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => mockForecastData,
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ properties: { refreshedGrid: true } }),
+        })
+
+      const forecast = await getNWSForecast(latitude, longitude)
+
+      expect(forecast).toEqual({
+        ...mockForecastData.properties,
+        gridData: { refreshedGrid: true },
+        radarStation: 'KSOX',
+      })
+      expect(fetch).toHaveBeenNthCalledWith(3, `https://api.weather.gov/points/${latitude},${longitude}`, {
+        headers: {
+          'User-Agent': 'CanIGoBoatingToday/1.0 (canigoboatingtoday.com, hello@canigoboatingtoday.com)',
+        },
+      })
+    })
+
     test('throws an error if coordinates are invalid', async () => {
       await expect(getNWSForecast(91, -118.2437)).rejects.toThrow('Invalid latitude or longitude provided.')
       await expect(getNWSForecast(34.0522, -181)).rejects.toThrow('Invalid latitude or longitude provided.')

--- a/components/WeatherDashboard.js
+++ b/components/WeatherDashboard.js
@@ -8,7 +8,7 @@ import TideChart from './TideChart'
 import { extractHourlyDataForDay } from '@/lib/dataTransformers'
 import { WindChart, PrecipChart, TempChart, WaveChart } from './charts/HourlyCharts'
 import DynamicRadarMap from './DynamicRadarMap'
-import { formatWeekdayLabel, getDailyPeriods, getLocalDateKey } from '@/lib/forecastPeriods'
+import { formatWeekdayLabel, getDailyForecastCards, getLocalDateKey } from '@/lib/forecastPeriods'
 import { parseWaveHeightValue } from '@/lib/forecastUtils'
 
 const DASHBOARD_CACHE_KEY = 'weatherDashboard:lastSuccessfulState'
@@ -189,6 +189,22 @@ function getGeolocationErrorMessage(error) {
   return 'Unable to get your current location.'
 }
 
+function formatSunTime(dateInput) {
+  if (!dateInput) return '--'
+
+  return new Intl.DateTimeFormat('en-US', {
+    hour: 'numeric',
+    minute: '2-digit',
+  }).format(new Date(dateInput))
+}
+
+function getSunWindowTimes(dayPeriod, nightPeriod) {
+  return {
+    sunrise: formatSunTime(dayPeriod?.startTime),
+    sunset: formatSunTime(nightPeriod?.startTime),
+  }
+}
+
 export default function WeatherDashboard() {
   const [location, setLocation] = useState(null)
   const [weatherData, setWeatherData] = useState(null)
@@ -311,13 +327,21 @@ export default function WeatherDashboard() {
   }, [])
 
   const fetchData = async (latitude, longitude, resolvedLocationName = locationName) => {
+    const previousState = {
+      location,
+      locationName,
+      weatherData,
+      tideData,
+      alertsData,
+      tideStatus,
+      alertsStatus,
+    }
+
     try {
       setLoading(true)
       setError(null)
       setTideStatus('loading')
       setAlertsStatus('loading')
-      setTideData(null)
-      setAlertsData(null)
 
       const forecastPromise = getNWSForecast(latitude, longitude)
       const tidePromise = getTideData(latitude, longitude).catch((tideError) => ({
@@ -364,11 +388,21 @@ export default function WeatherDashboard() {
         setAlertsStatus('error')
       }
     } catch (err) {
-      setWeatherData(null)
-      setTideData(null)
-      setAlertsData(null)
-      setTideStatus('idle')
-      setAlertsStatus('idle')
+      if (previousState.weatherData || previousState.tideData || previousState.alertsData) {
+        setLocation(previousState.location)
+        setLocationName(previousState.locationName)
+        setWeatherData(previousState.weatherData)
+        setTideData(previousState.tideData)
+        setAlertsData(previousState.alertsData)
+        setTideStatus(previousState.tideStatus)
+        setAlertsStatus(previousState.alertsStatus)
+      } else {
+        setWeatherData(null)
+        setTideData(null)
+        setAlertsData(null)
+        setTideStatus('idle')
+        setAlertsStatus('idle')
+      }
       setError(`Failed to fetch data: ${err.message}`)
       setLoading(false)
     }
@@ -392,13 +426,13 @@ export default function WeatherDashboard() {
     }
   }
 
-  const dailyPeriods = useMemo(() => getDailyPeriods(weatherData?.periods ?? []), [weatherData?.periods])
+  const dailyCards = useMemo(() => getDailyForecastCards(weatherData?.periods ?? []), [weatherData?.periods])
 
   // Extract date string for selected day
   const selectedDateStr = useMemo(() => {
-    if (!dailyPeriods[selectedDayIndex]) return null
-    return getLocalDateKey(dailyPeriods[selectedDayIndex].startTime)
-  }, [dailyPeriods, selectedDayIndex])
+    if (!dailyCards[selectedDayIndex]) return null
+    return dailyCards[selectedDayIndex].dateKey ?? getLocalDateKey(dailyCards[selectedDayIndex].startTime)
+  }, [dailyCards, selectedDayIndex])
 
   const hourlyData = useMemo(() => {
     if (!weatherData?.gridData || !selectedDateStr) return null
@@ -408,12 +442,11 @@ export default function WeatherDashboard() {
   const hourlyDataByDate = useMemo(() => {
     if (!weatherData?.gridData) return {}
 
-    return dailyPeriods.reduce((result, period) => {
-      const dateKey = getLocalDateKey(period.startTime)
-      result[dateKey] = extractHourlyDataForDay(weatherData.gridData, dateKey)
+    return dailyCards.reduce((result, card) => {
+      result[card.dateKey] = extractHourlyDataForDay(weatherData.gridData, card.dateKey)
       return result
     }, {})
-  }, [weatherData?.gridData, dailyPeriods])
+  }, [weatherData?.gridData, dailyCards])
 
   const waveChartData = useMemo(() => {
     if (!hourlyData) return null
@@ -423,13 +456,13 @@ export default function WeatherDashboard() {
       return hourlyData.wave
     }
 
-    const fallbackWaveValue = parseWaveHeightValue(dailyPeriods[selectedDayIndex]?.detailedForecast)
+    const fallbackWaveValue = parseWaveHeightValue(dailyCards[selectedDayIndex]?.detailedForecast)
     if (fallbackWaveValue === null) {
       return hasWaveSeriesData ? hourlyData.wave : hourlyData.wave.map(() => null)
     }
 
     return hourlyData.wave.map(() => fallbackWaveValue)
-  }, [hourlyData, dailyPeriods, selectedDayIndex])
+  }, [hourlyData, dailyCards, selectedDayIndex])
 
   const activeHourLabel = useMemo(() => {
     if (activeChartHour === null || activeChartHour === undefined || !hourlyData?.labels) return null
@@ -439,10 +472,10 @@ export default function WeatherDashboard() {
   const marineAlerts = alertsData?.alerts ?? []
 
   useEffect(() => {
-    if (selectedDayIndex >= dailyPeriods.length && dailyPeriods.length > 0) {
+    if (selectedDayIndex >= dailyCards.length && dailyCards.length > 0) {
       setSelectedDayIndex(0)
     }
-  }, [dailyPeriods.length, selectedDayIndex])
+  }, [dailyCards.length, selectedDayIndex])
 
   useEffect(() => {
     setActiveChartHour(null)
@@ -615,15 +648,16 @@ export default function WeatherDashboard() {
 
         {weatherData && (
           <div id="weather-forecast" className="w-full max-w-[1400px] px-3 sm:px-4 mt-5 flex gap-4 overflow-x-auto pb-2 snap-x snap-mandatory lg:grid lg:grid-cols-4 xl:grid-cols-7 lg:overflow-visible">
-            {dailyPeriods.map((period, index) => {
-              const icon = getForecastIconVariant(period.shortForecast)
+            {dailyCards.map((card, index) => {
+              const icon = getForecastIconVariant(card.shortForecast)
               const isSelected = index === selectedDayIndex
-              const dateKey = getLocalDateKey(period.startTime)
-              const dayHourlyData = hourlyDataByDate[dateKey] ?? null
+              const dayHourlyData = hourlyDataByDate[card.dateKey] ?? null
               const dayDecisions = BOATING_WINDOWS.map((window) => ({
                 ...window,
-                ...getDayDecision(dayHourlyData, period.detailedForecast, window.startHour, window.endHour),
+                ...getDayDecision(dayHourlyData, card.detailedForecast, window.startHour, window.endHour),
               }))
+              const { sunrise, sunset } = getSunWindowTimes(card.dayPeriod, card.nightPeriod)
+              const temperatureUnit = card.temperatureUnit || 'F'
 
               return (
               <div
@@ -632,44 +666,60 @@ export default function WeatherDashboard() {
                   onClick={() => setSelectedDayIndex(index)}
               >
                   <div>
-                    <h2 className="m-0 mb-[15px] text-[1.5em] font-semibold">{formatWeekdayLabel(period.startTime)}</h2>
+                    <h2 className="m-0 mb-[15px] text-[1.5em] font-semibold">{formatWeekdayLabel(card.startTime)}</h2>
                     <img
                       src={icon.src}
-                      alt={period.shortForecast}
+                      alt={card.shortForecast}
                       className="w-[70px] h-[70px] mx-auto mb-[15px]"
                       style={{ filter: icon.filter }}
                     />
-                    <div className="temp text-[1.2em] flex justify-center gap-[10px]">
-                        <span className="max font-bold">{period.temperature}&deg;{period.temperatureUnit}</span>
+                    <div className="temp text-[1.85em] flex justify-center items-baseline gap-[10px] font-semibold">
+                        <span className="max">{card.temperatureHigh ?? '--'}&deg;{temperatureUnit}</span>
+                        <span className="text-white/80">/</span>
+                        <span className="min text-[0.9em] text-white/85">{card.temperatureLow ?? '--'}&deg;{temperatureUnit}</span>
+                    </div>
+                    <div className="mt-5 grid grid-cols-2 gap-3 text-center">
+                      <div className="rounded-[14px] bg-white/12 px-3 py-2">
+                        <div className="text-[0.68rem] uppercase tracking-[0.18em] text-white/70">Sunrise</div>
+                        <div className="mt-1 text-[1.05em] font-semibold">{sunrise}</div>
+                      </div>
+                      <div className="rounded-[14px] bg-white/12 px-3 py-2">
+                        <div className="text-[0.68rem] uppercase tracking-[0.18em] text-white/70">Sunset</div>
+                        <div className="mt-1 text-[1.05em] font-semibold">{sunset}</div>
+                      </div>
                     </div>
                   </div>
 
                   <div className="mt-5">
-                    <div className="space-y-2">
+                    <div className="space-y-3">
                       {dayDecisions.map((decision) => (
                         <div
                           key={decision.key}
                           aria-label={
                             decision.reason
-                              ? `${decision.label} caution ${decision.reason.label.toLowerCase()}`
-                              : `${decision.label} favorable`
+                              ? `${decision.key} no ${decision.reason.label.toLowerCase()}`
+                              : `${decision.key} yes`
                           }
-                          className={`flex items-center justify-between rounded-full px-3 py-2 text-[0.82em] font-semibold ${
-                            decision.reason ? 'bg-red-500/18 text-red-50' : 'bg-emerald-500/18 text-emerald-50'
-                          }`}
+                          className="flex items-center justify-between text-[0.98em] font-semibold"
                         >
-                          <span className="text-[0.72rem] uppercase tracking-[0.16em] opacity-80">
-                            {decision.label}
+                          <span className="text-[0.9rem] uppercase tracking-[0.1em] text-white/90">
+                            {decision.key === 'morning' ? 'MORN:' : 'AFT:'}
                           </span>
-                          <span className="text-base">{decision.symbol}</span>
-                          <span className="min-w-[72px] text-right">
-                            {decision.reason ? `${decision.reason.icon} ${decision.reason.label}` : 'Good'}
+                          <span
+                            className={`ml-3 min-w-[48px] text-left text-[1.25em] ${
+                              decision.reason ? 'text-rose-300' : 'text-emerald-300'
+                            }`}
+                          >
+                            {decision.reason ? 'NO' : 'YES'}
+                          </span>
+                          <span className="ml-3 min-w-[74px] text-right text-[0.9rem] text-white/90">
+                            {decision.reason ? `${decision.reason.icon} ${decision.reason.label}` : 'Safe'}
                           </span>
                         </div>
                       ))}
                     </div>
-                    <div className="weather-description text-center mt-[14px] text-[0.9em] italic opacity-90">
-                      {period.detailedForecast}
+                    <div className="weather-description mt-[18px] text-center text-[1.02em] italic leading-7 opacity-95">
+                      {card.shortForecast}
                     </div>
                   </div>
               </div>
@@ -680,7 +730,7 @@ export default function WeatherDashboard() {
         {weatherData && location && (
           <div id="hourly-forecast-container" className="w-full max-w-[1400px] mt-[30px] px-3 sm:px-4">
             <div className="p-[18px] sm:p-[25px] bg-white/20 rounded-[15px] shadow-[0_8px_32px_0_rgba(31,38,135,0.37)] backdrop-blur-[4px]" style={{display: 'block'}}>
-              <h2 id="hourly-forecast-day" className="text-[1.8em] text-center mb-[20px]">{dailyPeriods[selectedDayIndex]?.name}</h2>
+              <h2 id="hourly-forecast-day" className="text-[1.8em] text-center mb-[20px]">{dailyCards[selectedDayIndex]?.name}</h2>
               <div id="charts-container" className="mt-[20px] flex flex-col gap-[15px]">
                   {hourlyData && (
                     <>

--- a/lib/forecastPeriods.js
+++ b/lib/forecastPeriods.js
@@ -28,6 +28,43 @@ export function getDailyPeriods(periods = []) {
     .slice(0, 7)
 }
 
+export function getDailyForecastCards(periods = []) {
+  const groupedPeriods = new Map()
+
+  for (const period of periods) {
+    const dateKey = getLocalDateKey(period.startTime)
+    const existing = groupedPeriods.get(dateKey) ?? []
+    existing.push(period)
+    groupedPeriods.set(dateKey, existing)
+  }
+
+  return Array.from(groupedPeriods.entries())
+    .map(([dateKey, group]) => {
+      const dayPeriod = group.find((period) => period.isDaytime) ?? group[0] ?? null
+      const nightPeriod = group.find((period) => period.isDaytime === false) ?? null
+      const anchorPeriod = dayPeriod ?? nightPeriod
+
+      if (!anchorPeriod) {
+        return null
+      }
+
+      return {
+        dateKey,
+        dayPeriod,
+        nightPeriod,
+        name: anchorPeriod.name,
+        startTime: anchorPeriod.startTime,
+        shortForecast: dayPeriod?.shortForecast ?? nightPeriod?.shortForecast ?? '',
+        detailedForecast: dayPeriod?.detailedForecast ?? nightPeriod?.detailedForecast ?? '',
+        temperatureHigh: dayPeriod?.temperature ?? anchorPeriod.temperature ?? null,
+        temperatureLow: nightPeriod?.temperature ?? null,
+        temperatureUnit: dayPeriod?.temperatureUnit ?? nightPeriod?.temperatureUnit ?? '',
+      }
+    })
+    .filter(Boolean)
+    .slice(0, 7)
+}
+
 export function formatWeekdayLabel(dateInput) {
   return new Intl.DateTimeFormat('en-US', { weekday: 'short' }).format(new Date(dateInput))
 }

--- a/lib/weatherService.js
+++ b/lib/weatherService.js
@@ -66,6 +66,16 @@ function buildCoordinateCacheKey(prefix, latitude, longitude) {
   return `${prefix}${latitude.toFixed(2)},${longitude.toFixed(2)}`
 }
 
+function clearCachedApiPayload(key, storageType = 'sessionStorage') {
+  if (typeof window === "undefined") return
+
+  try {
+    window[storageType].removeItem(key)
+  } catch (error) {
+    logError("Could not clear API cache:", error)
+  }
+}
+
 function extractZoneIdentifier(zoneUrl) {
   if (typeof zoneUrl !== 'string') return null
 
@@ -75,15 +85,21 @@ function extractZoneIdentifier(zoneUrl) {
   return trimmedZoneUrl.split('/').filter(Boolean).pop() ?? null
 }
 
-async function getNWSPointMetadata(latitude, longitude) {
+async function getNWSPointMetadata(latitude, longitude, { forceRefresh = false } = {}) {
   if (!isValidCoordinate(latitude, longitude)) {
     throw new Error("Invalid latitude or longitude provided.");
   }
 
   const cacheKey = buildCoordinateCacheKey(POINTS_CACHE_PREFIX, latitude, longitude)
-  const cachedPointMetadata = getCachedApiPayload(cacheKey, POINTS_CACHE_DURATION_MS)
+  const cachedPointMetadata = forceRefresh
+    ? null
+    : getCachedApiPayload(cacheKey, POINTS_CACHE_DURATION_MS)
   if (cachedPointMetadata) {
     return cachedPointMetadata
+  }
+
+  if (forceRefresh) {
+    clearCachedApiPayload(cacheKey)
   }
 
   const pointsUrl = `https://api.weather.gov/points/${encodeURIComponent(latitude)},${encodeURIComponent(longitude)}`
@@ -92,14 +108,49 @@ async function getNWSPointMetadata(latitude, longitude) {
   })
 
   if (!pointsResponse.ok) {
-    throw new Error(
+    const error = new Error(
       `NWS points API request failed: ${pointsResponse.statusText}`,
     )
+    error.status = pointsResponse.status
+    throw error
   }
 
   const pointsData = await pointsResponse.json()
   cacheApiPayload(cacheKey, pointsData)
   return pointsData
+}
+
+async function fetchForecastFromPointMetadata(pointsData) {
+  const forecastUrl = pointsData.properties.forecast
+  const gridDataUrl = pointsData.properties.forecastGridData
+
+  if (!forecastUrl) {
+    throw new Error("Could not retrieve forecast URL from NWS points data.")
+  }
+
+  const requests = [fetch(forecastUrl, { headers: NWS_HEADERS })]
+  if (gridDataUrl) {
+    requests.push(fetch(gridDataUrl, { headers: NWS_HEADERS }))
+  }
+
+  const [forecastResponse, gridDataResponse] = await Promise.all(requests)
+
+  if (!forecastResponse.ok) {
+    const error = new Error(
+      `NWS forecast API request failed: ${forecastResponse.statusText}`,
+    )
+    error.status = forecastResponse.status
+    throw error
+  }
+
+  const forecastData = await forecastResponse.json()
+  const gridData = gridDataResponse?.ok ? await gridDataResponse.json() : null
+
+  return {
+    ...forecastData.properties,
+    gridData: gridData ? gridData.properties : null,
+    radarStation: pointsData.properties?.radarStation ?? null,
+  }
 }
 
 export async function geocodeLocation(query) {
@@ -146,39 +197,28 @@ export async function getNWSForecast(latitude, longitude) {
 
   try {
     const cacheKey = buildCoordinateCacheKey(FORECAST_CACHE_PREFIX, latitude, longitude)
+    const pointsCacheKey = buildCoordinateCacheKey(POINTS_CACHE_PREFIX, latitude, longitude)
     const cachedForecast = getCachedApiPayload(cacheKey, FORECAST_CACHE_DURATION_MS)
     if (cachedForecast) {
       return cachedForecast
     }
 
-    const pointsData = await getNWSPointMetadata(latitude, longitude)
-    const forecastUrl = pointsData.properties.forecast;
-    const gridDataUrl = pointsData.properties.forecastGridData; // <-- Add this
+    let pointsData = await getNWSPointMetadata(latitude, longitude)
+    let result
 
-    if (!forecastUrl) {
-      throw new Error("Could not retrieve forecast URL from NWS points data.");
+    try {
+      result = await fetchForecastFromPointMetadata(pointsData)
+    } catch (forecastError) {
+      if (forecastError.status !== 404) {
+        throw forecastError
+      }
+
+      clearCachedApiPayload(cacheKey)
+      clearCachedApiPayload(pointsCacheKey)
+      pointsData = await getNWSPointMetadata(latitude, longitude, { forceRefresh: true })
+      result = await fetchForecastFromPointMetadata(pointsData)
     }
 
-    // Step 2: Get the actual forecast using the gridpoint URL and the grid data
-    const [forecastResponse, gridDataResponse] = await Promise.all([
-      fetch(forecastUrl, { headers: NWS_HEADERS }),
-      fetch(gridDataUrl, { headers: NWS_HEADERS })
-    ]);
-
-    if (!forecastResponse.ok) {
-      throw new Error(
-        `NWS forecast API request failed: ${forecastResponse.statusText}`,
-      );
-    }
-
-    const forecastData = await forecastResponse.json();
-    const gridData = gridDataResponse.ok ? await gridDataResponse.json() : null;
-
-    const result = {
-      ...forecastData.properties,
-      gridData: gridData ? gridData.properties : null,
-      radarStation: pointsData.properties?.radarStation ?? null,
-    };
     cacheApiPayload(cacheKey, result)
     return result
   } catch (error) {

--- a/tests/app.spec.js
+++ b/tests/app.spec.js
@@ -247,8 +247,10 @@ test.describe('Can I go boating today? App - E2E', () => {
     await expect(page.locator('#charts-container .chart-container')).toHaveCount(5, { timeout: 15000 })
     await expect(page.getByText('Wave Forecast')).toHaveCount(0)
     await expect(page.getByText('Wave N/A')).toHaveCount(0)
-    await expect(page.locator('[aria-label="AM favorable"]')).toHaveCount(1)
-    await expect(page.locator('[aria-label="PM favorable"]')).toBeVisible()
+    await expect(page.getByText('Sunrise').first()).toBeVisible()
+    await expect(page.getByText('Sunset').first()).toBeVisible()
+    await expect(page.locator('[aria-label="morning yes"]')).toHaveCount(1)
+    await expect(page.locator('[aria-label="afternoon yes"]')).toBeVisible()
     await expect(page.getByText('Small Craft Advisory').first()).toBeVisible()
     await expect(page.locator('#radar-map-container')).toBeVisible()
 


### PR DESCRIPTION
## What changed
- restored the day-grid cards to a more concise old-style boating summary with hi/low temperatures, sunrise and sunset time blocks, and clear morning/afternoon go-no-go guidance
- paired daytime and nighttime forecast periods into a dedicated daily-card model for the dashboard layout
- retried NWS forecast lookups with fresh /points metadata when cached gridpoint forecast URLs return 404
- preserved the last successful dashboard state when a refresh fails so the charts do not disappear
- updated Jest and Playwright coverage for the new card layout and the stale-NWS retry path

## Why
The current day cards had drifted away from the fast decision-making layout boaters need, and stale cached NWS point metadata could leave the app requesting expired gridpoints/forecast URLs.

## Validation
- npm test -- --runInBand __tests__/weatherService.test.js __tests__/forecastPeriods.test.js __tests__/WeatherDashboard.test.js __tests__/RadarMap.test.js
- npm run test:e2e -- tests/app.spec.js