### PR TITLE
[codex] Update Pages workflow and flush stale weather caches

### DIFF
--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -24,13 +24,16 @@ concurrency:
   group: "pages"
   cancel-in-progress: false
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   # Build job
   build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Detect package manager
         id: detect-package-manager
         run: |
@@ -49,14 +52,14 @@ jobs:
             exit 1
           fi
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "24"
           cache: ${{ steps.detect-package-manager.outputs.manager }}
       - name: Setup Pages
         uses: actions/configure-pages@v5
       - name: Restore cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             .next/cache
@@ -70,7 +73,7 @@ jobs:
       - name: Build with Next.js
         run: ${{ steps.detect-package-manager.outputs.runner }} next build --webpack
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
         with:
           path: ./out
 

--- a/__tests__/WeatherDashboard.test.js
+++ b/__tests__/WeatherDashboard.test.js
@@ -47,7 +47,7 @@ jest.mock('@/components/charts/HourlyCharts', () => ({
   ),
 }))
 
-const DASHBOARD_CACHE_KEY = 'weatherDashboard:lastSuccessfulState'
+const DASHBOARD_CACHE_KEY = 'weatherDashboard:v2:lastSuccessfulState'
 
 function buildWeatherData() {
   return {

--- a/__tests__/weatherService.test.js
+++ b/__tests__/weatherService.test.js
@@ -86,7 +86,7 @@ describe('weatherService', () => {
 
     test('returns cached forecast data without refetching', async () => {
       sessionStorage.setItem(
-        'forecast:34.05,-118.24',
+        'forecast:v2:34.05,-118.24',
         JSON.stringify({
           timestamp: Date.now(),
           payload: { periods: [{ name: 'Cached Today' }], gridData: { cached: true } },
@@ -137,7 +137,7 @@ describe('weatherService', () => {
 
     test('refreshes stale point metadata and retries once when the forecast URL returns 404', async () => {
       sessionStorage.setItem(
-        'points:34.05,-118.24',
+        'points:v2:34.05,-118.24',
         JSON.stringify({
           timestamp: Date.now(),
           payload: {
@@ -291,7 +291,7 @@ describe('weatherService', () => {
 
     test('returns cached alerts without refetching', async () => {
       sessionStorage.setItem(
-        'alerts:34.05,-118.24',
+        'alerts:v2:34.05,-118.24',
         JSON.stringify({
           timestamp: Date.now(),
           payload: {
@@ -350,7 +350,7 @@ describe('weatherService', () => {
 
     test('returns cached tide data without refetching', async () => {
       sessionStorage.setItem(
-        'tideData:34.05,-118.24',
+        'tideData:v2:34.05,-118.24',
         JSON.stringify({
           timestamp: Date.now(),
           payload: { predictions: [{ t: '2026-04-16 13:00', v: '1.9' }] },
@@ -373,7 +373,7 @@ describe('weatherService', () => {
   describe('geocodeLocation', () => {
     test('returns cached geocode results without refetching', async () => {
       localStorage.setItem(
-        'geocode:san diego',
+        'geocode:v2:san diego',
         JSON.stringify({
           timestamp: Date.now(),
           payload: { name: 'San Diego', latitude: 32.7157, longitude: -117.1611 },

--- a/components/WeatherDashboard.js
+++ b/components/WeatherDashboard.js
@@ -11,7 +11,7 @@ import DynamicRadarMap from './DynamicRadarMap'
 import { formatWeekdayLabel, getDailyForecastCards, getLocalDateKey } from '@/lib/forecastPeriods'
 import { parseWaveHeightValue } from '@/lib/forecastUtils'
 
-const DASHBOARD_CACHE_KEY = 'weatherDashboard:lastSuccessfulState'
+const DASHBOARD_CACHE_KEY = 'weatherDashboard:v2:lastSuccessfulState'
 const DASHBOARD_CACHE_MAX_AGE_MS = 30 * 60 * 1000
 const GEOLOCATION_OPTIONS = {
   enableHighAccuracy: false,

--- a/lib/weatherService.js
+++ b/lib/weatherService.js
@@ -10,11 +10,12 @@ import { error as logError } from "./logger.js";
 // The NWS API requires a unique User-Agent header for all requests.
 // This helps them identify the application making the request.
 const NWS_USER_AGENT = `CanIGoBoatingToday/1.0 (canigoboatingtoday.com, hello@canigoboatingtoday.com)`
-const FORECAST_CACHE_PREFIX = 'forecast:'
-const POINTS_CACHE_PREFIX = 'points:'
-const TIDE_DATA_CACHE_PREFIX = 'tideData:'
-const GEOCODE_CACHE_PREFIX = 'geocode:'
-const ALERTS_CACHE_PREFIX = 'alerts:'
+const CLIENT_CACHE_VERSION = 'v2'
+const FORECAST_CACHE_PREFIX = `forecast:${CLIENT_CACHE_VERSION}:`
+const POINTS_CACHE_PREFIX = `points:${CLIENT_CACHE_VERSION}:`
+const TIDE_DATA_CACHE_PREFIX = `tideData:${CLIENT_CACHE_VERSION}:`
+const GEOCODE_CACHE_PREFIX = `geocode:${CLIENT_CACHE_VERSION}:`
+const ALERTS_CACHE_PREFIX = `alerts:${CLIENT_CACHE_VERSION}:`
 const POINTS_CACHE_DURATION_MS = 30 * 60 * 1000
 const FORECAST_CACHE_DURATION_MS = 10 * 60 * 1000
 const TIDE_DATA_CACHE_DURATION_MS = 30 * 60 * 1000

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -22,8 +22,34 @@ const pwaConfig = {
 let withPWA = (config) => config
 
 try {
-  const { default: withPWAInit } = await import('@ducanh2912/next-pwa')
-  withPWA = withPWAInit(pwaConfig)
+  const {
+    default: withPWAInit,
+    runtimeCaching: defaultRuntimeCaching,
+  } = await import('@ducanh2912/next-pwa')
+
+  const runtimeCaching = defaultRuntimeCaching.map((entry) => {
+    const cacheName = entry.options?.cacheName
+
+    if (cacheName === 'next-static-js-assets' || cacheName === 'static-js-assets') {
+      return {
+        ...entry,
+        handler: 'NetworkFirst',
+        options: {
+          ...entry.options,
+          networkTimeoutSeconds: 3,
+        },
+      }
+    }
+
+    return entry
+  })
+
+  withPWA = withPWAInit({
+    ...pwaConfig,
+    workboxOptions: {
+      runtimeCaching,
+    },
+  })
 } catch (error) {
   console.warn('next-pwa could not be loaded; continuing without PWA support.', error)
 }


### PR DESCRIPTION
## What changed
- updated the GitHub Pages workflow to Node 24-era action versions and opted the workflow into the Node 24 JavaScript action runtime now
- versioned the client-side weather, alert, geocode, tide, and dashboard cache keys so stale browser storage is flushed on deploy
- changed the PWA runtime caching for JavaScript assets away from CacheFirst so newly deployed app bundles are fetched fresh instead of sticking to an older cached bundle
- updated the weather/dashboard cache tests for the new versioned keys

## Why
GitHub is deprecating Node 20 for JavaScript actions, and the app was also vulnerable to stale client caches keeping an older bundle or stale NWS point metadata around. That combination could leave users on code that still requested expired api.weather.gov forecast URLs.

## Validation
- npm test -- --runInBand __tests__/weatherService.test.js __tests__/forecastPeriods.test.js __tests__/WeatherDashboard.test.js __tests__/RadarMap.test.js
- npm run build
- npm run test:e2e -- tests/app.spec.js