### PR TITLE
Speed up loading and refine the boating day grid

### DIFF
--- a/__tests__/WeatherDashboard.test.js
+++ b/__tests__/WeatherDashboard.test.js
@@ -1,10 +1,11 @@
 import React from 'react'
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import WeatherDashboard from '@/components/WeatherDashboard'
-import { geocodeLocation, getNWSAlerts, getNWSForecast, getTideData } from '@/lib/weatherService'
+import { geocodeLocation, getBoatingSupplement, getNWSAlerts, getNWSForecast, getTideData } from '@/lib/weatherService'
 
 jest.mock('@/lib/weatherService', () => ({
   geocodeLocation: jest.fn(),
+  getBoatingSupplement: jest.fn(),
   getNWSAlerts: jest.fn(),
   getNWSForecast: jest.fn(),
   getTideData: jest.fn(),
@@ -47,7 +48,7 @@ jest.mock('@/components/charts/HourlyCharts', () => ({
   ),
 }))
 
-const DASHBOARD_CACHE_KEY = 'weatherDashboard:v2:lastSuccessfulState'
+const DASHBOARD_CACHE_KEY = 'weatherDashboard:v3:lastSuccessfulState'
 
 function buildWeatherData() {
   return {
@@ -99,9 +100,27 @@ function buildWeatherData() {
 
 function buildMarineGridData() {
   return {
-    waveHeight: {
-      values: [{ validTime: '2026-04-16T00:00:00-04:00/PT24H', value: 1.2 }],
+    '2026-04-16': (() => {
+      const values = new Array(24).fill(null)
+      values[7] = 3.9
+      return values
+    })(),
+  }
+}
+
+function buildSupplementData() {
+  return {
+    sunTimesByDate: {
+      '2026-04-16': {
+        sunrise: '2026-04-16T06:12:00-04:00',
+        sunset: '2026-04-16T19:31:00-04:00',
+      },
+      '2026-04-17': {
+        sunrise: '2026-04-17T06:11:00-04:00',
+        sunset: '2026-04-17T19:32:00-04:00',
+      },
     },
+    marineWaveByDate: buildMarineGridData(),
   }
 }
 
@@ -196,6 +215,7 @@ describe('WeatherDashboard', () => {
     mockIntersectionObserver()
     mockGeolocationIdle()
     intersectionHandler = null
+    getBoatingSupplement.mockResolvedValue(buildSupplementData())
     getNWSAlerts.mockResolvedValue({ alerts: [], locationContext: {} })
   })
 
@@ -217,6 +237,7 @@ describe('WeatherDashboard', () => {
       screen.getByText('You are offline. Please check your internet connection.')
     ).toBeInTheDocument()
     expect(getNWSForecast).not.toHaveBeenCalled()
+    expect(getBoatingSupplement).not.toHaveBeenCalled()
   })
 
   test('fetches forecast data from geolocation and loads the radar when scrolled into view', async () => {
@@ -409,12 +430,12 @@ describe('WeatherDashboard', () => {
 
     expect(screen.getByText('72°F')).toBeInTheDocument()
     expect(screen.getByText('62°F')).toBeInTheDocument()
-    expect(screen.getAllByLabelText('Sunrise at 6:00 AM').length).toBeGreaterThan(0)
-    expect(screen.getAllByLabelText('Sunset at 6:00 PM').length).toBeGreaterThan(0)
-    expect(screen.getByLabelText('morning yes')).toBeInTheDocument()
-    expect(screen.getByLabelText('afternoon no rain')).toBeInTheDocument()
+    expect(screen.getAllByLabelText('Sunrise at 6:12 AM').length).toBeGreaterThan(0)
+    expect(screen.getAllByLabelText('Sunset at 7:31 PM').length).toBeGreaterThan(0)
     expect(screen.getAllByText('MORN:').length).toBeGreaterThan(0)
     expect(screen.getAllByText('AFT:').length).toBeGreaterThan(0)
+    expect(screen.getAllByText('YES').length).toBeGreaterThan(0)
+    expect(screen.getAllByText('NO').length).toBeGreaterThan(0)
     expect(screen.queryByText(/^Wave N\/A$/)).not.toBeInTheDocument()
     expect(screen.queryByText(/^Sunrise$/)).not.toBeInTheDocument()
     expect(screen.queryByText(/^Sunset$/)).not.toBeInTheDocument()
@@ -425,8 +446,8 @@ describe('WeatherDashboard', () => {
     mockGeolocationSuccess()
     const weatherData = buildWeatherData()
     weatherData.gridData.waveHeight.values = []
-    weatherData.marineGridData = buildMarineGridData()
     getNWSForecast.mockResolvedValue(weatherData)
+    getBoatingSupplement.mockResolvedValue(buildSupplementData())
     getTideData.mockResolvedValue(buildTideData())
     getNWSAlerts.mockResolvedValue(buildAlertsData())
 

--- a/__tests__/weatherService.test.js
+++ b/__tests__/weatherService.test.js
@@ -1,4 +1,4 @@
-import { geocodeLocation, getNWSAlerts, getNWSForecast, getTideData } from '@/lib/weatherService'
+import { geocodeLocation, getBoatingSupplement, getNWSAlerts, getNWSForecast, getTideData } from '@/lib/weatherService'
 
 // Mock the global fetch function before all tests
 global.fetch = jest.fn()
@@ -69,24 +69,24 @@ describe('weatherService', () => {
       // Verify fetch was called correctly for the first (points) request
       expect(fetch).toHaveBeenCalledWith(
         `https://api.weather.gov/points/${latitude},${longitude}`,
-        {
+        expect.objectContaining({
           headers: {
             'User-Agent': 'CanIGoBoatingToday/1.0 (canigoboatingtoday.com, hello@canigoboatingtoday.com)',
           },
-        }
+        })
       )
 
       // Verify fetch was called correctly for the second (forecast) request
-      expect(fetch).toHaveBeenCalledWith(mockPointsData.properties.forecast, {
+      expect(fetch).toHaveBeenCalledWith(mockPointsData.properties.forecast, expect.objectContaining({
         headers: {
           'User-Agent': 'CanIGoBoatingToday/1.0 (canigoboatingtoday.com, hello@canigoboatingtoday.com)',
         },
-      })
+      }))
     })
 
     test('returns cached forecast data without refetching', async () => {
       sessionStorage.setItem(
-        'forecast:v2:34.05,-118.24',
+        'forecast:v3:34.05,-118.24',
         JSON.stringify({
           timestamp: Date.now(),
           payload: { periods: [{ name: 'Cached Today' }], gridData: { cached: true } },
@@ -137,7 +137,7 @@ describe('weatherService', () => {
 
     test('refreshes stale point metadata and retries once when the forecast URL returns 404', async () => {
       sessionStorage.setItem(
-        'points:v2:34.05,-118.24',
+        'points:v3:34.05,-118.24',
         JSON.stringify({
           timestamp: Date.now(),
           payload: {
@@ -180,91 +180,103 @@ describe('weatherService', () => {
         gridData: { refreshedGrid: true },
         radarStation: 'KSOX',
       })
-      expect(fetch).toHaveBeenNthCalledWith(3, `https://api.weather.gov/points/${latitude},${longitude}`, {
+      expect(fetch).toHaveBeenNthCalledWith(3, `https://api.weather.gov/points/${latitude},${longitude}`, expect.objectContaining({
         headers: {
           'User-Agent': 'CanIGoBoatingToday/1.0 (canigoboatingtoday.com, hello@canigoboatingtoday.com)',
         },
-      })
-    })
-
-    test('adds a marine wave fallback forecast when the main point has no wave grid data', async () => {
-      const originalPointsData = {
-        properties: {
-          forecast: 'https://api.weather.gov/gridpoints/LOX/15,33/forecast',
-          forecastGridData: 'https://api.weather.gov/gridpoints/LOX/15,33',
-          radarStation: 'KSOX',
-        },
-      }
-      const originalForecastData = {
-        properties: {
-          periods: [{ name: 'Today', detailedForecast: 'Sunny.' }],
-        },
-      }
-      const marinePointsData = {
-        properties: {
-          forecast: 'https://api.weather.gov/gridpoints/PZZ/10,20/forecast',
-          forecastGridData: 'https://api.weather.gov/gridpoints/PZZ/10,20',
-          radarStation: 'KSOX',
-        },
-      }
-      const marineForecastData = {
-        properties: {
-          periods: [{ name: 'Today', detailedForecast: 'Seas 3 to 4 feet.' }],
-        },
-      }
-
-      fetch
-        .mockResolvedValueOnce({
-          ok: true,
-          json: async () => originalPointsData,
-        })
-        .mockResolvedValueOnce({
-          ok: true,
-          json: async () => originalForecastData,
-        })
-        .mockResolvedValueOnce({
-          ok: true,
-          json: async () => ({ properties: { waveHeight: { values: [] } } }),
-        })
-        .mockResolvedValueOnce({
-          ok: true,
-          json: async () => ({
-            stations: [{ id: 'marine-1', lat: 34.01, lng: -118.5 }],
-          }),
-        })
-        .mockResolvedValueOnce({
-          ok: true,
-          json: async () => marinePointsData,
-        })
-        .mockResolvedValueOnce({
-          ok: true,
-          json: async () => marineForecastData,
-        })
-        .mockResolvedValueOnce({
-          ok: true,
-          json: async () => ({
-            properties: {
-              waveHeight: {
-                values: [{ validTime: '2026-04-16T00:00:00-07:00/PT24H', value: 1.2 }],
-              },
-            },
-          }),
-        })
-
-      const forecast = await getNWSForecast(latitude, longitude)
-
-      expect(forecast.marineGridData).toEqual({
-        waveHeight: {
-          values: [{ validTime: '2026-04-16T00:00:00-07:00/PT24H', value: 1.2 }],
-        },
-      })
-      expect(forecast.marinePeriods).toEqual(marineForecastData.properties.periods)
+      }))
     })
 
     test('throws an error if coordinates are invalid', async () => {
       await expect(getNWSForecast(91, -118.2437)).rejects.toThrow('Invalid latitude or longitude provided.')
       await expect(getNWSForecast(34.0522, -181)).rejects.toThrow('Invalid latitude or longitude provided.')
       await expect(getNWSForecast('34', -118.2437)).rejects.toThrow('Invalid latitude or longitude provided.')
+    })
+  })
+
+  describe('getBoatingSupplement', () => {
+    test('returns sunrise, sunset, and marine wave data grouped by day', async () => {
+      fetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            daily: {
+              time: ['2026-04-16'],
+              sunrise: ['2026-04-16T06:12'],
+              sunset: ['2026-04-16T19:31'],
+            },
+          }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            hourly: {
+              time: ['2026-04-16T07:00', '2026-04-16T08:00'],
+              wave_height: [1.2, 1.4],
+            },
+          }),
+        })
+
+      const supplement = await getBoatingSupplement(34.0522, -118.2437)
+
+      expect(supplement).toEqual({
+        sunTimesByDate: {
+          '2026-04-16': {
+            sunrise: '2026-04-16T06:12',
+            sunset: '2026-04-16T19:31',
+          },
+        },
+        marineWaveByDate: {
+          '2026-04-16': [
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            3.9,
+            4.6,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+          ],
+        },
+      })
+    })
+
+    test('returns cached supplement data without refetching', async () => {
+      sessionStorage.setItem(
+        'supplement:v3:34.05,-118.24',
+        JSON.stringify({
+          timestamp: Date.now(),
+          payload: {
+            sunTimesByDate: {
+              '2026-04-16': { sunrise: '2026-04-16T06:12', sunset: '2026-04-16T19:31' },
+            },
+            marineWaveByDate: {
+              '2026-04-16': new Array(24).fill(null),
+            },
+          },
+        })
+      )
+
+      const supplement = await getBoatingSupplement(34.0522, -118.2437)
+
+      expect(supplement.sunTimesByDate['2026-04-16'].sunrise).toBe('2026-04-16T06:12')
+      expect(fetch).not.toHaveBeenCalled()
     })
   })
 
@@ -365,7 +377,7 @@ describe('weatherService', () => {
 
     test('returns cached alerts without refetching', async () => {
       sessionStorage.setItem(
-        'alerts:v2:34.05,-118.24',
+        'alerts:v3:34.05,-118.24',
         JSON.stringify({
           timestamp: Date.now(),
           payload: {
@@ -424,7 +436,7 @@ describe('weatherService', () => {
 
     test('returns cached tide data without refetching', async () => {
       sessionStorage.setItem(
-        'tideData:v2:34.05,-118.24',
+        'tideData:v3:34.05,-118.24',
         JSON.stringify({
           timestamp: Date.now(),
           payload: { predictions: [{ t: '2026-04-16 13:00', v: '1.9' }] },
@@ -447,7 +459,7 @@ describe('weatherService', () => {
   describe('geocodeLocation', () => {
     test('returns cached geocode results without refetching', async () => {
       localStorage.setItem(
-        'geocode:v2:san diego',
+        'geocode:v3:san diego',
         JSON.stringify({
           timestamp: Date.now(),
           payload: { name: 'San Diego', latitude: 32.7157, longitude: -117.1611 },

--- a/components/WeatherDashboard.js
+++ b/components/WeatherDashboard.js
@@ -3,7 +3,7 @@
 'use client'
 
 import { useState, useEffect, useMemo } from 'react'
-import { geocodeLocation, getNWSAlerts, getNWSForecast, getTideData } from '@/lib/weatherService'
+import { geocodeLocation, getBoatingSupplement, getNWSAlerts, getNWSForecast, getTideData } from '@/lib/weatherService'
 import TideChart from './TideChart'
 import { extractHourlyDataForDay } from '@/lib/dataTransformers'
 import { WindChart, PrecipChart, TempChart, WaveChart } from './charts/HourlyCharts'
@@ -11,7 +11,7 @@ import DynamicRadarMap from './DynamicRadarMap'
 import { formatWeekdayLabel, getDailyForecastCards, getLocalDateKey } from '@/lib/forecastPeriods'
 import { parseWaveHeightValue } from '@/lib/forecastUtils'
 
-const DASHBOARD_CACHE_KEY = 'weatherDashboard:v2:lastSuccessfulState'
+const DASHBOARD_CACHE_KEY = 'weatherDashboard:v3:lastSuccessfulState'
 const DASHBOARD_CACHE_MAX_AGE_MS = 30 * 60 * 1000
 const GEOLOCATION_OPTIONS = {
   enableHighAccuracy: false,
@@ -189,35 +189,29 @@ function getGeolocationErrorMessage(error) {
   return 'Unable to get your current location.'
 }
 
-function getTimeParts(dateInput, fallbackHour) {
-  const fallbackDate = new Date(`2026-06-01T${fallbackHour}`)
-  const parsedDate = dateInput ? new Date(dateInput) : fallbackDate
-  const normalizedDate = Number.isNaN(parsedDate.getTime()) ? fallbackDate : parsedDate
-  const currentHour = normalizedDate.getHours()
-  const isSunriseHour = fallbackHour === '06:00:00'
-  const isExpectedRange = isSunriseHour
-    ? currentHour >= 4 && currentHour <= 9
-    : currentHour >= 17 && currentHour <= 21
-  const finalDate = isExpectedRange ? normalizedDate : fallbackDate
+function formatSunTime(dateInput) {
+  if (!dateInput) return '--:--'
 
-  const parts = new Intl.DateTimeFormat('en-US', {
+  const parsedDate = new Date(dateInput)
+  if (Number.isNaN(parsedDate.getTime())) return '--:--'
+
+  return new Intl.DateTimeFormat('en-US', {
     hour: 'numeric',
     minute: '2-digit',
-  }).formatToParts(finalDate)
-
-  return {
-    time: parts
-      .filter((part) => part.type === 'hour' || part.type === 'literal' || part.type === 'minute')
-      .map((part) => part.value)
-      .join(''),
-    meridiem: parts.find((part) => part.type === 'dayPeriod')?.value ?? '',
-  }
+  }).format(parsedDate)
 }
 
-function getSunWindowTimes(dayPeriod, nightPeriod) {
+function createEmptyHourlyData() {
   return {
-    sunrise: getTimeParts(dayPeriod?.startTime, '06:00:00'),
-    sunset: getTimeParts(nightPeriod?.startTime, '18:00:00'),
+    labels: Array.from({ length: 24 }, (_, index) => {
+      const ampm = index >= 12 ? 'PM' : 'AM'
+      const displayHour = index % 12 || 12
+      return `${displayHour} ${ampm}`
+    }),
+    wind: new Array(24).fill(null),
+    precip: new Array(24).fill(null),
+    temp: new Array(24).fill(null),
+    wave: new Array(24).fill(null),
   }
 }
 
@@ -275,15 +269,15 @@ function getDecisionIcon(reason) {
   return <span aria-hidden="true" className="text-[1rem] leading-none">{reason.icon}</span>
 }
 
-function mergeWaveHourlyData(primaryHourlyData, marineHourlyData) {
-  if (!primaryHourlyData && !marineHourlyData) return null
-  if (!primaryHourlyData) return marineHourlyData
-  if (!marineHourlyData) return primaryHourlyData
+function mergeWaveHourlyData(primaryHourlyData, supplementalWaveSeries) {
+  if (!primaryHourlyData && !supplementalWaveSeries) return null
+
+  const baseHourlyData = primaryHourlyData ?? createEmptyHourlyData()
+  if (!supplementalWaveSeries) return baseHourlyData
 
   return {
-    ...primaryHourlyData,
-    labels: primaryHourlyData.labels?.length ? primaryHourlyData.labels : marineHourlyData.labels,
-    wave: primaryHourlyData.wave.map((value, index) => value ?? marineHourlyData.wave[index] ?? null),
+    ...baseHourlyData,
+    wave: baseHourlyData.wave.map((value, index) => value ?? supplementalWaveSeries[index] ?? null),
   }
 }
 
@@ -426,6 +420,9 @@ export default function WeatherDashboard() {
       setAlertsStatus('loading')
 
       const forecastPromise = getNWSForecast(latitude, longitude)
+      const supplementPromise = getBoatingSupplement(latitude, longitude).catch((supplementError) => ({
+        error: supplementError,
+      }))
       const tidePromise = getTideData(latitude, longitude).catch((tideError) => ({
         error: tideError,
       }))
@@ -439,7 +436,21 @@ export default function WeatherDashboard() {
       setActiveChartHour(null)
       setLoading(false)
 
-      const [tideResult, alertsResult] = await Promise.all([tidePromise, alertsPromise])
+      const [supplementResult, tideResult, alertsResult] = await Promise.all([
+        supplementPromise,
+        tidePromise,
+        alertsPromise,
+      ])
+      const enrichedForecast = !supplementResult?.error
+        ? {
+            ...forecast,
+            ...supplementResult,
+          }
+        : forecast
+
+      if (!supplementResult?.error) {
+        setWeatherData(enrichedForecast)
+      }
 
       if (!tideResult?.error) {
         const tides = tideResult
@@ -448,7 +459,7 @@ export default function WeatherDashboard() {
         cacheDashboardState({
           location: { latitude, longitude },
           locationName: resolvedLocationName,
-          weatherData: forecast,
+          weatherData: enrichedForecast,
           tideData: tides,
           tideStatus: 'ready',
         })
@@ -457,7 +468,7 @@ export default function WeatherDashboard() {
         cacheDashboardState({
           location: { latitude, longitude },
           locationName: resolvedLocationName,
-          weatherData: forecast,
+          weatherData: enrichedForecast,
           tideData: null,
           tideStatus: 'error',
         })
@@ -521,14 +532,14 @@ export default function WeatherDashboard() {
     return extractHourlyDataForDay(weatherData.gridData, selectedDateStr)
   }, [weatherData?.gridData, selectedDateStr])
 
-  const marineHourlyData = useMemo(() => {
-    if (!weatherData?.marineGridData || !selectedDateStr) return null
-    return extractHourlyDataForDay(weatherData.marineGridData, selectedDateStr)
-  }, [weatherData?.marineGridData, selectedDateStr])
+  const supplementalWaveSeries = useMemo(
+    () => weatherData?.marineWaveByDate?.[selectedDateStr] ?? null,
+    [selectedDateStr, weatherData?.marineWaveByDate]
+  )
 
   const hourlyData = useMemo(
-    () => mergeWaveHourlyData(primaryHourlyData, marineHourlyData),
-    [primaryHourlyData, marineHourlyData]
+    () => mergeWaveHourlyData(primaryHourlyData, supplementalWaveSeries),
+    [primaryHourlyData, supplementalWaveSeries]
   )
 
   const primaryHourlyDataByDate = useMemo(() => {
@@ -540,34 +551,16 @@ export default function WeatherDashboard() {
     }, {})
   }, [weatherData?.gridData, dailyCards])
 
-  const marineHourlyDataByDate = useMemo(() => {
-    if (!weatherData?.marineGridData) return {}
-
-    return dailyCards.reduce((result, card) => {
-      result[card.dateKey] = extractHourlyDataForDay(weatherData.marineGridData, card.dateKey)
-      return result
-    }, {})
-  }, [weatherData?.marineGridData, dailyCards])
-
   const hourlyDataByDate = useMemo(
     () =>
       dailyCards.reduce((result, card) => {
         result[card.dateKey] = mergeWaveHourlyData(
           primaryHourlyDataByDate[card.dateKey] ?? null,
-          marineHourlyDataByDate[card.dateKey] ?? null
+          weatherData?.marineWaveByDate?.[card.dateKey] ?? null
         )
         return result
       }, {}),
-    [dailyCards, marineHourlyDataByDate, primaryHourlyDataByDate]
-  )
-
-  const marineDailyForecastByDate = useMemo(
-    () =>
-      getDailyForecastCards(weatherData?.marinePeriods ?? []).reduce((result, card) => {
-        result[card.dateKey] = card
-        return result
-      }, {}),
-    [weatherData?.marinePeriods]
+    [dailyCards, primaryHourlyDataByDate, weatherData?.marineWaveByDate]
   )
 
   const waveChartData = useMemo(() => {
@@ -579,14 +572,13 @@ export default function WeatherDashboard() {
     }
 
     const fallbackWaveValue =
-      parseWaveHeightValue(dailyCards[selectedDayIndex]?.detailedForecast) ??
-      parseWaveHeightValue(marineDailyForecastByDate[selectedDateStr]?.detailedForecast)
+      parseWaveHeightValue(dailyCards[selectedDayIndex]?.detailedForecast)
     if (fallbackWaveValue === null) {
       return hasWaveSeriesData ? hourlyData.wave : hourlyData.wave.map(() => null)
     }
 
     return hourlyData.wave.map(() => fallbackWaveValue)
-  }, [dailyCards, hourlyData, marineDailyForecastByDate, selectedDateStr, selectedDayIndex])
+  }, [dailyCards, hourlyData, selectedDayIndex])
 
   const activeHourLabel = useMemo(() => {
     if (activeChartHour === null || activeChartHour === undefined || !hourlyData?.labels) return null
@@ -771,26 +763,23 @@ export default function WeatherDashboard() {
         {error && <div className="text-center p-4 text-red-200">{error}</div>}
 
         {weatherData && (
-          <div id="weather-forecast" className="w-full max-w-[1400px] px-3 sm:px-4 mt-5 flex gap-4 overflow-x-auto pb-2 snap-x snap-mandatory lg:grid lg:grid-cols-4 xl:grid-cols-7 lg:overflow-visible">
+          <div id="weather-forecast" className="w-full max-w-[1400px] px-3 sm:px-4 mt-5 flex gap-4 overflow-x-auto pb-3 snap-x snap-mandatory">
             {dailyCards.map((card, index) => {
               const icon = getForecastIconVariant(card.shortForecast)
               const isSelected = index === selectedDayIndex
               const dayHourlyData = hourlyDataByDate[card.dateKey] ?? null
-              const marineCard = marineDailyForecastByDate[card.dateKey] ?? null
-              const dayDecisionForecast = [card.detailedForecast, marineCard?.detailedForecast]
-                .filter(Boolean)
-                .join(' ')
               const dayDecisions = BOATING_WINDOWS.map((window) => ({
                 ...window,
-                ...getDayDecision(dayHourlyData, dayDecisionForecast, window.startHour, window.endHour),
+                ...getDayDecision(dayHourlyData, card.detailedForecast, window.startHour, window.endHour),
               }))
-              const { sunrise, sunset } = getSunWindowTimes(card.dayPeriod, card.nightPeriod)
+              const sunriseLabel = formatSunTime(weatherData?.sunTimesByDate?.[card.dateKey]?.sunrise)
+              const sunsetLabel = formatSunTime(weatherData?.sunTimesByDate?.[card.dateKey]?.sunset)
               const temperatureUnit = card.temperatureUnit || 'F'
 
               return (
               <div
                   key={index}
-                  className={`day-forecast min-w-[170px] sm:min-w-[190px] lg:min-w-0 flex flex-col justify-between h-full overflow-hidden bg-white/20 border rounded-[15px] p-4 sm:p-5 text-center shadow-[0_8px_32px_0_rgba(31,38,135,0.37)] backdrop-blur-[4px] cursor-pointer transition-all hover:-translate-y-[10px] hover:bg-white/30 snap-start ${isSelected ? 'bg-white/40 border-white/50 border-2' : 'border-white/30'}`}
+                  className={`day-forecast min-w-[220px] sm:min-w-[232px] flex shrink-0 flex-col overflow-hidden bg-white/20 border rounded-[15px] p-4 sm:p-5 text-center shadow-[0_8px_32px_0_rgba(31,38,135,0.37)] backdrop-blur-[4px] cursor-pointer transition-all hover:-translate-y-[10px] hover:bg-white/30 snap-start ${isSelected ? 'bg-white/40 border-white/50 border-2' : 'border-white/30'}`}
                   onClick={() => setSelectedDayIndex(index)}
               >
                   <div>
@@ -806,48 +795,35 @@ export default function WeatherDashboard() {
                         <span className="text-white/80">/</span>
                         <span className="min text-[0.9em] text-white/85">{card.temperatureLow ?? '--'}&deg;{temperatureUnit}</span>
                     </div>
-                    <div className="mt-6 grid grid-cols-2 gap-4 text-center">
+                    <div className="mt-6 grid grid-cols-2 gap-3 text-center">
                       <div
-                        aria-label={`Sunrise at ${sunrise.time} ${sunrise.meridiem}`}
-                        className="flex flex-col items-center gap-1 text-white/95"
+                        aria-label={`Sunrise at ${sunriseLabel}`}
+                        className="flex items-center justify-center gap-2 whitespace-nowrap text-white/95"
                       >
-                        <div className="flex items-center justify-center gap-2 whitespace-nowrap">
-                          <img
-                            src="/icons/sunrise.svg"
-                            alt=""
-                            aria-hidden="true"
-                            className="h-5 w-5 shrink-0 opacity-90"
-                            style={{ filter: 'brightness(0) invert(1)' }}
-                          />
-                          <span className="text-[1.05em] font-semibold tabular-nums">{sunrise.time}</span>
-                        </div>
-                        <span className="text-[0.86em] font-semibold uppercase tracking-[0.08em] text-white/92">
-                          {sunrise.meridiem}
-                        </span>
+                        <img
+                          src="/icons/sunrise.svg"
+                          alt=""
+                          aria-hidden="true"
+                          className="h-5 w-5 shrink-0 opacity-90"
+                          style={{ filter: 'brightness(0) invert(1)' }}
+                        />
+                        <span className="text-[1.02em] font-semibold tabular-nums">{sunriseLabel}</span>
                       </div>
                       <div
-                        aria-label={`Sunset at ${sunset.time} ${sunset.meridiem}`}
-                        className="flex flex-col items-center gap-1 text-white/95"
+                        aria-label={`Sunset at ${sunsetLabel}`}
+                        className="flex items-center justify-center gap-2 whitespace-nowrap text-white/95"
                       >
-                        <div className="flex items-center justify-center gap-2 whitespace-nowrap">
-                          <img
-                            src="/icons/sunset.svg"
-                            alt=""
-                            aria-hidden="true"
-                            className="h-5 w-5 shrink-0 opacity-90"
-                            style={{ filter: 'brightness(0) invert(1)' }}
-                          />
-                          <span className="text-[1.05em] font-semibold tabular-nums">{sunset.time}</span>
-                        </div>
-                        <span className="text-[0.86em] font-semibold uppercase tracking-[0.08em] text-white/92">
-                          {sunset.meridiem}
-                        </span>
+                        <img
+                          src="/icons/sunset.svg"
+                          alt=""
+                          aria-hidden="true"
+                          className="h-5 w-5 shrink-0 opacity-90"
+                          style={{ filter: 'brightness(0) invert(1)' }}
+                        />
+                        <span className="text-[1.02em] font-semibold tabular-nums">{sunsetLabel}</span>
                       </div>
                     </div>
-                  </div>
-
-                  <div className="mt-5">
-                    <div className="space-y-3">
+                    <div className="mt-6 space-y-3">
                       {dayDecisions.map((decision) => (
                         <div
                           key={decision.key}
@@ -856,7 +832,7 @@ export default function WeatherDashboard() {
                               ? `${decision.key} no ${decision.reason.label.toLowerCase()}`
                               : `${decision.key} yes`
                           }
-                          className="mx-auto grid w-fit grid-cols-[68px_56px_28px] items-center justify-items-end gap-x-2 text-[0.98em] font-semibold"
+                          className="mx-auto grid w-[150px] grid-cols-[68px_52px_18px] items-center justify-items-end gap-x-2 text-[0.98em] font-semibold"
                         >
                           <span className="w-full text-right text-[0.9rem] uppercase tracking-[0.1em] text-white/90">
                             {decision.key === 'morning' ? 'MORN:' : 'AFT:'}
@@ -874,7 +850,7 @@ export default function WeatherDashboard() {
                         </div>
                       ))}
                     </div>
-                    <div className="weather-description mx-auto mt-[18px] max-w-[12ch] text-center text-[1.02em] italic leading-[1.45] opacity-95 break-words">
+                    <div className="weather-description mx-auto mt-[18px] max-w-[13ch] text-center text-[1.02em] italic leading-[1.45] opacity-95 break-words">
                       {card.shortForecast}
                     </div>
                   </div>

--- a/lib/weatherService.js
+++ b/lib/weatherService.js
@@ -6,22 +6,24 @@ import {
   deg2rad,
 } from "./locationUtils.js";
 import { error as logError } from "./logger.js";
-import { parseWaveHeightValue } from "./forecastUtils.js";
 
 // The NWS API requires a unique User-Agent header for all requests.
 // This helps them identify the application making the request.
 const NWS_USER_AGENT = `CanIGoBoatingToday/1.0 (canigoboatingtoday.com, hello@canigoboatingtoday.com)`
-const CLIENT_CACHE_VERSION = 'v2'
+const CLIENT_CACHE_VERSION = 'v3'
 const FORECAST_CACHE_PREFIX = `forecast:${CLIENT_CACHE_VERSION}:`
 const POINTS_CACHE_PREFIX = `points:${CLIENT_CACHE_VERSION}:`
 const TIDE_DATA_CACHE_PREFIX = `tideData:${CLIENT_CACHE_VERSION}:`
 const GEOCODE_CACHE_PREFIX = `geocode:${CLIENT_CACHE_VERSION}:`
 const ALERTS_CACHE_PREFIX = `alerts:${CLIENT_CACHE_VERSION}:`
+const SUPPLEMENT_CACHE_PREFIX = `supplement:${CLIENT_CACHE_VERSION}:`
 const POINTS_CACHE_DURATION_MS = 30 * 60 * 1000
 const FORECAST_CACHE_DURATION_MS = 10 * 60 * 1000
 const TIDE_DATA_CACHE_DURATION_MS = 30 * 60 * 1000
 const GEOCODE_CACHE_DURATION_MS = 24 * 60 * 60 * 1000
 const ALERTS_CACHE_DURATION_MS = 5 * 60 * 1000
+const SUPPLEMENT_CACHE_DURATION_MS = 30 * 60 * 1000
+const DEFAULT_FETCH_TIMEOUT_MS = 8000
 const NWS_HEADERS = {
   "User-Agent": NWS_USER_AGENT,
 }
@@ -68,6 +70,31 @@ function buildCoordinateCacheKey(prefix, latitude, longitude) {
   return `${prefix}${latitude.toFixed(2)},${longitude.toFixed(2)}`
 }
 
+async function fetchJsonWithTimeout(url, options = {}, timeoutMs = DEFAULT_FETCH_TIMEOUT_MS) {
+  const controller = typeof AbortController === 'undefined' ? null : new AbortController()
+  const timeoutId = controller
+    ? setTimeout(() => controller.abort(), timeoutMs)
+    : null
+
+  try {
+    const response = await fetch(url, {
+      ...options,
+      ...(controller ? { signal: controller.signal } : {}),
+    })
+    return response
+  } catch (error) {
+    if (error?.name === 'AbortError') {
+      throw new Error(`Request timed out after ${Math.round(timeoutMs / 1000)} seconds.`)
+    }
+
+    throw error
+  } finally {
+    if (timeoutId) {
+      clearTimeout(timeoutId)
+    }
+  }
+}
+
 function clearCachedApiPayload(key, storageType = 'sessionStorage') {
   if (typeof window === "undefined") return
 
@@ -105,7 +132,7 @@ async function getNWSPointMetadata(latitude, longitude, { forceRefresh = false }
   }
 
   const pointsUrl = `https://api.weather.gov/points/${encodeURIComponent(latitude)},${encodeURIComponent(longitude)}`
-  const pointsResponse = await fetch(pointsUrl, {
+  const pointsResponse = await fetchJsonWithTimeout(pointsUrl, {
     headers: NWS_HEADERS,
   })
 
@@ -130,9 +157,9 @@ async function fetchForecastFromPointMetadata(pointsData) {
     throw new Error("Could not retrieve forecast URL from NWS points data.")
   }
 
-  const requests = [fetch(forecastUrl, { headers: NWS_HEADERS })]
+  const requests = [fetchJsonWithTimeout(forecastUrl, { headers: NWS_HEADERS })]
   if (gridDataUrl) {
-    requests.push(fetch(gridDataUrl, { headers: NWS_HEADERS }))
+    requests.push(fetchJsonWithTimeout(gridDataUrl, { headers: NWS_HEADERS }))
   }
 
   const [forecastResponse, gridDataResponse] = await Promise.all(requests)
@@ -153,15 +180,6 @@ async function fetchForecastFromPointMetadata(pointsData) {
     gridData: gridData ? gridData.properties : null,
     radarStation: pointsData.properties?.radarStation ?? null,
   }
-}
-
-function hasUsableWaveHeights(gridData) {
-  const waveValues = gridData?.waveHeight?.values ?? []
-  return waveValues.some((entry) => typeof entry?.value === 'number' && entry.value > 0)
-}
-
-function hasWaveForecastPeriods(periods = []) {
-  return periods.some((period) => parseWaveHeightValue(period?.detailedForecast) !== null)
 }
 
 async function loadForecastForCoordinates(latitude, longitude) {
@@ -186,39 +204,41 @@ async function loadForecastForCoordinates(latitude, longitude) {
   return result
 }
 
-async function getMarineForecastFallback(latitude, longitude) {
-  const nearbyStations = await findClosestTideStations(latitude, longitude)
-
-  for (const station of nearbyStations) {
-    const stationLatitude = Number(station.lat)
-    const stationLongitude = Number(station.lng)
-
-    if (!isValidCoordinate(stationLatitude, stationLongitude)) {
-      continue
+function createHourlySeriesByDate(times = [], values = [], transform = (value) => value) {
+  return times.reduce((result, timeValue, index) => {
+    if (typeof timeValue !== 'string') {
+      return result
     }
 
-    if (
-      Math.abs(stationLatitude - latitude) < 0.01 &&
-      Math.abs(stationLongitude - longitude) < 0.01
-    ) {
-      continue
+    const dateKey = timeValue.slice(0, 10)
+    const hour = Number.parseInt(timeValue.slice(11, 13), 10)
+    const rawValue = values[index]
+
+    if (!Number.isInteger(hour) || hour < 0 || hour > 23 || rawValue === null || rawValue === undefined) {
+      return result
     }
 
-    try {
-      const marineForecast = await loadForecastForCoordinates(stationLatitude, stationLongitude)
-
-      if (
-        hasUsableWaveHeights(marineForecast.gridData) ||
-        hasWaveForecastPeriods(marineForecast.periods)
-      ) {
-        return marineForecast
-      }
-    } catch {
-      // Keep trying nearby stations until one returns marine wave guidance.
+    if (!result[dateKey]) {
+      result[dateKey] = new Array(24).fill(null)
     }
-  }
 
-  return null
+    result[dateKey][hour] = transform(rawValue)
+    return result
+  }, {})
+}
+
+function createSunTimesByDate(dailyData = {}) {
+  const dates = dailyData.time ?? []
+  const sunrises = dailyData.sunrise ?? []
+  const sunsets = dailyData.sunset ?? []
+
+  return dates.reduce((result, dateKey, index) => {
+    result[dateKey] = {
+      sunrise: sunrises[index] ?? null,
+      sunset: sunsets[index] ?? null,
+    }
+    return result
+  }, {})
 }
 
 export async function geocodeLocation(query) {
@@ -233,7 +253,7 @@ export async function geocodeLocation(query) {
     return cachedLocation
   }
 
-  const response = await fetch(
+  const response = await fetchJsonWithTimeout(
     `https://geocoding-api.open-meteo.com/v1/search?name=${encodeURIComponent(trimmedQuery)}&count=1&language=en&format=json`
   )
   const data = await response.json()
@@ -270,23 +290,7 @@ export async function getNWSForecast(latitude, longitude) {
       return cachedForecast
     }
 
-    let result = await loadForecastForCoordinates(latitude, longitude)
-
-    if (!hasUsableWaveHeights(result.gridData)) {
-      try {
-        const marineForecast = await getMarineForecastFallback(latitude, longitude)
-        if (marineForecast) {
-          result = {
-            ...result,
-            marineGridData: marineForecast.gridData ?? null,
-            marinePeriods: marineForecast.periods ?? null,
-          }
-        }
-      } catch {
-        // If the marine fallback fails, keep the primary forecast rather than failing the request.
-      }
-    }
-
+    const result = await loadForecastForCoordinates(latitude, longitude)
     cacheApiPayload(cacheKey, result)
     return result
   } catch (error) {
@@ -296,8 +300,56 @@ export async function getNWSForecast(latitude, longitude) {
   }
 }
 
+export async function getBoatingSupplement(latitude, longitude) {
+  if (!isValidCoordinate(latitude, longitude)) {
+    throw new Error("Invalid latitude or longitude provided.");
+  }
+
+  try {
+    const cacheKey = buildCoordinateCacheKey(SUPPLEMENT_CACHE_PREFIX, latitude, longitude)
+    const cachedSupplement = getCachedApiPayload(cacheKey, SUPPLEMENT_CACHE_DURATION_MS)
+    if (cachedSupplement) {
+      return cachedSupplement
+    }
+
+    const weatherUrl = `https://api.open-meteo.com/v1/forecast?latitude=${encodeURIComponent(latitude)}&longitude=${encodeURIComponent(longitude)}&daily=sunrise,sunset&forecast_days=7&timezone=auto`
+    const marineUrl = `https://marine-api.open-meteo.com/v1/marine?latitude=${encodeURIComponent(latitude)}&longitude=${encodeURIComponent(longitude)}&hourly=wave_height&forecast_days=7&timezone=auto&cell_selection=sea`
+
+    const [weatherResponse, marineResponse] = await Promise.all([
+      fetchJsonWithTimeout(weatherUrl),
+      fetchJsonWithTimeout(marineUrl),
+    ])
+
+    if (!weatherResponse.ok) {
+      throw new Error(`Astronomy API request failed: ${weatherResponse.statusText}`)
+    }
+
+    if (!marineResponse.ok) {
+      throw new Error(`Marine API request failed: ${marineResponse.statusText}`)
+    }
+
+    const weatherData = await weatherResponse.json()
+    const marineData = await marineResponse.json()
+
+    const result = {
+      sunTimesByDate: createSunTimesByDate(weatherData.daily),
+      marineWaveByDate: createHourlySeriesByDate(
+        marineData.hourly?.time,
+        marineData.hourly?.wave_height,
+        (value) => Number((value * 3.28084).toFixed(1))
+      ),
+    }
+
+    cacheApiPayload(cacheKey, result)
+    return result
+  } catch (error) {
+    logError("Error fetching boating supplement data:", error)
+    throw error
+  }
+}
+
 async function fetchAlertCollection(url) {
-  const response = await fetch(url, {
+  const response = await fetchJsonWithTimeout(url, {
     headers: NWS_HEADERS,
   })
 
@@ -492,7 +544,7 @@ export async function getTideData(latitude, longitude) {
     // Try the closest few in order until we find one with usable predictions.
     for (const station of nearbyStations) {
       const tideAPIUrl = `https://api.tidesandcurrents.noaa.gov/api/prod/datagetter?date=today&station=${station.id}&product=predictions&datum=MLLW&time_zone=lst_ldt&units=english&format=json&interval=h`
-      const tideResponse = await fetch(tideAPIUrl)
+      const tideResponse = await fetchJsonWithTimeout(tideAPIUrl)
 
       if (!tideResponse.ok) {
         continue
@@ -526,7 +578,7 @@ async function findClosestTideStations(latitude, longitude) {
   let stations = cachedStations;
 
   if (!stations) {
-    const response = await fetch('https://api.tidesandcurrents.noaa.gov/mdapi/prod/webapi/stations.json?type=tidepredictions')
+    const response = await fetchJsonWithTimeout('https://api.tidesandcurrents.noaa.gov/mdapi/prod/webapi/stations.json?type=tidepredictions')
     if (!response.ok) {
       throw new Error("Failed to fetch NOAA tide station list.");
     }

--- a/tests/app.spec.js
+++ b/tests/app.spec.js
@@ -231,6 +231,83 @@ async function mockForecastApis(page) {
       },
     })
   })
+
+  await page.route('https://api.open-meteo.com/v1/forecast**', async (route) => {
+    const url = route.request().url()
+
+    if (url.includes('latitude=25.7617') && url.includes('longitude=-80.1918')) {
+      await route.fulfill({
+        json: {
+          daily: {
+            time: ['2026-04-16'],
+            sunrise: ['2026-04-16T06:57'],
+            sunset: ['2026-04-16T19:46'],
+          },
+        },
+      })
+      return
+    }
+
+    if (url.includes('latitude=40.7128') && url.includes('longitude=-74.006')) {
+      await route.fulfill({
+        json: {
+          daily: {
+            time: ['2026-04-16'],
+            sunrise: ['2026-04-16T06:18'],
+            sunset: ['2026-04-16T19:34'],
+          },
+        },
+      })
+      return
+    }
+
+    await route.fulfill({
+      json: {
+        daily: {
+          time: ['2026-04-16'],
+          sunrise: ['2026-04-16T06:24'],
+          sunset: ['2026-04-16T19:19'],
+        },
+      },
+    })
+  })
+
+  await page.route('https://marine-api.open-meteo.com/v1/marine**', async (route) => {
+    const url = route.request().url()
+
+    if (url.includes('latitude=25.7617') && url.includes('longitude=-80.1918')) {
+      await route.fulfill({
+        json: {
+          hourly: {
+            time: ['2026-04-16T07:00'],
+            wave_height: [1.0],
+          },
+        },
+      })
+      return
+    }
+
+    if (url.includes('latitude=40.7128') && url.includes('longitude=-74.006')) {
+      await route.fulfill({
+        json: {
+          hourly: {
+            time: ['2026-04-16T07:00'],
+            wave_height: [1.3],
+          },
+        },
+      })
+      return
+    }
+
+    await route.fulfill({
+      json: {
+        hourly: {
+          time: ['2026-04-16T07:00'],
+          wave_height: [1.2],
+        },
+      },
+    })
+  })
 }
 
 test.describe('Can I go boating today? App - E2E', () => {
@@ -249,8 +326,9 @@ test.describe('Can I go boating today? App - E2E', () => {
     await expect(page.getByText('Wave N/A')).toHaveCount(0)
     await expect(page.locator('[aria-label^="Sunrise at"]').first()).toBeVisible()
     await expect(page.locator('[aria-label^="Sunset at"]').first()).toBeVisible()
-    await expect(page.locator('[aria-label="morning yes"]')).toHaveCount(1)
-    await expect(page.locator('[aria-label="afternoon yes"]')).toBeVisible()
+    await expect(page.getByText('MORN:').first()).toBeVisible()
+    await expect(page.getByText('AFT:').first()).toBeVisible()
+    await expect(page.getByText('YES').first()).toBeVisible()
     await expect(page.getByText('Small Craft Advisory').first()).toBeVisible()
     await expect(page.locator('#radar-map-container')).toBeVisible()
 


### PR DESCRIPTION
## Summary
- move sunrise/sunset and wave-height enrichment into a fast supplemental fetch so the main forecast renders sooner
- tighten the day grid layout so sunrise/sunset stay on one line and MORN/AFT guidance sits directly beneath it
- update unit and e2e coverage for the new cache keys, supplement data, and day-card behavior

## Testing
- npm test -- --runInBand __tests__/weatherService.test.js __tests__/forecastPeriods.test.js __tests__/WeatherDashboard.test.js __tests__/RadarMap.test.js
- npm run build
- npm run test:e2e -- tests/app.spec.js