### PR TITLE
Backfill hourly weather and extend wave continuity

### DIFF
--- a/__tests__/WeatherDashboard.test.js
+++ b/__tests__/WeatherDashboard.test.js
@@ -103,8 +103,44 @@ function buildMarineGridData() {
     '2026-04-16': (() => {
       const values = new Array(24).fill(null)
       values[7] = 3.9
+      values[8] = 3.9
+      values[9] = 3.9
       return values
     })(),
+    '2026-04-17': (() => {
+      const values = new Array(24).fill(null)
+      values[7] = 4.2
+      values[8] = 4.2
+      values[9] = 4.2
+      return values
+    })(),
+  }
+}
+
+function buildWeatherHourlySupplement() {
+  return {
+    '2026-04-16': {
+      wind: (() => {
+        const values = new Array(24).fill(null)
+        values[0] = 8
+        values[1] = 8
+        values[2] = 8
+        values[3] = 8
+        values[4] = 8
+        values[5] = 9
+        values[6] = 9
+        values[7] = 10
+        values[8] = 10
+        return values
+      })(),
+      temp: new Array(24).fill(68),
+      precip: new Array(24).fill(15),
+    },
+    '2026-04-17': {
+      wind: new Array(24).fill(11),
+      temp: new Array(24).fill(70),
+      precip: new Array(24).fill(25),
+    },
   }
 }
 
@@ -120,6 +156,7 @@ function buildSupplementData() {
         sunset: '2026-04-17T19:32:00-04:00',
       },
     },
+    weatherHourlyByDate: buildWeatherHourlySupplement(),
     marineWaveByDate: buildMarineGridData(),
   }
 }
@@ -459,6 +496,27 @@ describe('WeatherDashboard', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Wave Height (ft)' }))
     expect(screen.getByText('3.9 ft')).toBeInTheDocument()
+  })
+
+  test('backs fills missing current-day wind hours from supplemental hourly weather data', async () => {
+    mockGeolocationSuccess()
+    const weatherData = buildWeatherData()
+    weatherData.gridData.windSpeed.values = [
+      { validTime: '2026-04-16T09:00:00-04:00/PT15H', value: 16 },
+    ]
+    getNWSForecast.mockResolvedValue(weatherData)
+    getBoatingSupplement.mockResolvedValue(buildSupplementData())
+    getTideData.mockResolvedValue(buildTideData())
+    getNWSAlerts.mockResolvedValue(buildAlertsData())
+
+    render(<WeatherDashboard />)
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Thu' })).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Wind Speed (mph)' }))
+    expect(screen.getByText('9 mph')).toBeInTheDocument()
   })
 
   test('does not render an alert banner when no marine alerts are active', async () => {

--- a/__tests__/weatherService.test.js
+++ b/__tests__/weatherService.test.js
@@ -205,56 +205,41 @@ describe('weatherService', () => {
               sunrise: ['2026-04-16T06:12'],
               sunset: ['2026-04-16T19:31'],
             },
+            hourly: {
+              time: ['2026-04-16T00:00', '2026-04-16T01:00'],
+              temperature_2m: [20, 20],
+              wind_speed_10m: [12.9, 12.9],
+              precipitation_probability: [15, 15],
+            },
           }),
         })
         .mockResolvedValueOnce({
           ok: true,
           json: async () => ({
             hourly: {
-              time: ['2026-04-16T07:00', '2026-04-16T08:00'],
-              wave_height: [1.2, 1.4],
+              time: ['2026-04-16T07:00', '2026-04-16T10:00', '2026-04-17T07:00'],
+              wave_height: [1.2, 1.4, 1.5],
             },
           }),
         })
 
       const supplement = await getBoatingSupplement(34.0522, -118.2437)
 
-      expect(supplement).toEqual({
-        sunTimesByDate: {
-          '2026-04-16': {
-            sunrise: '2026-04-16T06:12',
-            sunset: '2026-04-16T19:31',
-          },
-        },
-        marineWaveByDate: {
-          '2026-04-16': [
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            3.9,
-            4.6,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-          ],
+      expect(supplement.sunTimesByDate).toEqual({
+        '2026-04-16': {
+          sunrise: '2026-04-16T06:12',
+          sunset: '2026-04-16T19:31',
         },
       })
+      expect(supplement.weatherHourlyByDate['2026-04-16'].temp[0]).toBe(68)
+      expect(supplement.weatherHourlyByDate['2026-04-16'].wind[0]).toBe(8)
+      expect(supplement.weatherHourlyByDate['2026-04-16'].wind[23]).toBe(8)
+      expect(supplement.weatherHourlyByDate['2026-04-16'].precip[12]).toBe(15)
+      expect(supplement.marineWaveByDate['2026-04-16'][7]).toBe(3.9)
+      expect(supplement.marineWaveByDate['2026-04-16'][10]).toBe(4.6)
+      expect(supplement.marineWaveByDate['2026-04-16'][23]).toBe(4.6)
+      expect(supplement.marineWaveByDate['2026-04-17'][7]).toBe(4.9)
+      expect(supplement.marineWaveByDate['2026-04-17'][23]).toBe(4.9)
     })
 
     test('returns cached supplement data without refetching', async () => {

--- a/components/WeatherDashboard.js
+++ b/components/WeatherDashboard.js
@@ -269,15 +269,25 @@ function getDecisionIcon(reason) {
   return <span aria-hidden="true" className="text-[1rem] leading-none">{reason.icon}</span>
 }
 
-function mergeWaveHourlyData(primaryHourlyData, supplementalWaveSeries) {
-  if (!primaryHourlyData && !supplementalWaveSeries) return null
+function mergeHourlyData(primaryHourlyData, supplementalWeatherData, supplementalWaveSeries) {
+  if (!primaryHourlyData && !supplementalWeatherData && !supplementalWaveSeries) return null
 
   const baseHourlyData = primaryHourlyData ?? createEmptyHourlyData()
-  if (!supplementalWaveSeries) return baseHourlyData
 
   return {
     ...baseHourlyData,
-    wave: baseHourlyData.wave.map((value, index) => value ?? supplementalWaveSeries[index] ?? null),
+    wind: baseHourlyData.wind.map(
+      (value, index) => value ?? supplementalWeatherData?.wind?.[index] ?? null
+    ),
+    precip: baseHourlyData.precip.map(
+      (value, index) => value ?? supplementalWeatherData?.precip?.[index] ?? null
+    ),
+    temp: baseHourlyData.temp.map(
+      (value, index) => value ?? supplementalWeatherData?.temp?.[index] ?? null
+    ),
+    wave: baseHourlyData.wave.map(
+      (value, index) => value ?? supplementalWaveSeries?.[index] ?? null
+    ),
   }
 }
 
@@ -536,10 +546,14 @@ export default function WeatherDashboard() {
     () => weatherData?.marineWaveByDate?.[selectedDateStr] ?? null,
     [selectedDateStr, weatherData?.marineWaveByDate]
   )
+  const supplementalWeatherData = useMemo(
+    () => weatherData?.weatherHourlyByDate?.[selectedDateStr] ?? null,
+    [selectedDateStr, weatherData?.weatherHourlyByDate]
+  )
 
   const hourlyData = useMemo(
-    () => mergeWaveHourlyData(primaryHourlyData, supplementalWaveSeries),
-    [primaryHourlyData, supplementalWaveSeries]
+    () => mergeHourlyData(primaryHourlyData, supplementalWeatherData, supplementalWaveSeries),
+    [primaryHourlyData, supplementalWeatherData, supplementalWaveSeries]
   )
 
   const primaryHourlyDataByDate = useMemo(() => {
@@ -554,13 +568,14 @@ export default function WeatherDashboard() {
   const hourlyDataByDate = useMemo(
     () =>
       dailyCards.reduce((result, card) => {
-        result[card.dateKey] = mergeWaveHourlyData(
+        result[card.dateKey] = mergeHourlyData(
           primaryHourlyDataByDate[card.dateKey] ?? null,
+          weatherData?.weatherHourlyByDate?.[card.dateKey] ?? null,
           weatherData?.marineWaveByDate?.[card.dateKey] ?? null
         )
         return result
       }, {}),
-    [dailyCards, primaryHourlyDataByDate, weatherData?.marineWaveByDate]
+    [dailyCards, primaryHourlyDataByDate, weatherData?.marineWaveByDate, weatherData?.weatherHourlyByDate]
   )
 
   const waveChartData = useMemo(() => {

--- a/lib/weatherService.js
+++ b/lib/weatherService.js
@@ -204,25 +204,85 @@ async function loadForecastForCoordinates(latitude, longitude) {
   return result
 }
 
-function createHourlySeriesByDate(times = [], values = [], transform = (value) => value) {
-  return times.reduce((result, timeValue, index) => {
-    if (typeof timeValue !== 'string') {
-      return result
-    }
+function createHourlySeriesByDate(times = [], values = [], transform = (value) => value, { fillToNext = false } = {}) {
+  const result = {}
+  const parsedEntries = times
+    .map((timeValue, index) => {
+      if (typeof timeValue !== 'string') return null
 
-    const dateKey = timeValue.slice(0, 10)
-    const hour = Number.parseInt(timeValue.slice(11, 13), 10)
-    const rawValue = values[index]
+      const parsedDate = new Date(timeValue)
+      const rawValue = values[index]
+      if (Number.isNaN(parsedDate.getTime()) || rawValue === null || rawValue === undefined) {
+        return null
+      }
 
-    if (!Number.isInteger(hour) || hour < 0 || hour > 23 || rawValue === null || rawValue === undefined) {
-      return result
-    }
+      return {
+        parsedDate,
+        rawValue,
+      }
+    })
+    .filter(Boolean)
+
+  parsedEntries.forEach((entry, index) => {
+    const dateKey = `${entry.parsedDate.getFullYear()}-${String(entry.parsedDate.getMonth() + 1).padStart(2, '0')}-${String(entry.parsedDate.getDate()).padStart(2, '0')}`
+    const hour = entry.parsedDate.getHours()
 
     if (!result[dateKey]) {
       result[dateKey] = new Array(24).fill(null)
     }
 
-    result[dateKey][hour] = transform(rawValue)
+    const transformedValue = transform(entry.rawValue)
+    result[dateKey][hour] = transformedValue
+
+    if (!fillToNext) {
+      return
+    }
+
+    const nextEntry = parsedEntries[index + 1] ?? null
+    const nextDate = nextEntry ? nextEntry.parsedDate : null
+    const endHourExclusive =
+      nextDate && nextDate.toDateString() === entry.parsedDate.toDateString()
+        ? Math.min(24, nextDate.getHours())
+        : 24
+
+    for (let fillHour = hour + 1; fillHour < endHourExclusive; fillHour += 1) {
+      result[dateKey][fillHour] = transformedValue
+    }
+  })
+
+  return result
+}
+
+function createWeatherHourlyByDate(hourlyData = {}) {
+  const temperatureByDate = createHourlySeriesByDate(
+    hourlyData.time,
+    hourlyData.temperature_2m,
+    (value) => Math.round(value * 9/5 + 32),
+    { fillToNext: true }
+  )
+  const windByDate = createHourlySeriesByDate(
+    hourlyData.time,
+    hourlyData.wind_speed_10m,
+    (value) => Math.round(value * 0.621371),
+    { fillToNext: true }
+  )
+  const precipByDate = createHourlySeriesByDate(
+    hourlyData.time,
+    hourlyData.precipitation_probability,
+    (value) => value,
+    { fillToNext: true }
+  )
+
+  return Object.keys({
+    ...temperatureByDate,
+    ...windByDate,
+    ...precipByDate,
+  }).reduce((result, dateKey) => {
+    result[dateKey] = {
+      temp: temperatureByDate[dateKey] ?? new Array(24).fill(null),
+      wind: windByDate[dateKey] ?? new Array(24).fill(null),
+      precip: precipByDate[dateKey] ?? new Array(24).fill(null),
+    }
     return result
   }, {})
 }
@@ -312,7 +372,7 @@ export async function getBoatingSupplement(latitude, longitude) {
       return cachedSupplement
     }
 
-    const weatherUrl = `https://api.open-meteo.com/v1/forecast?latitude=${encodeURIComponent(latitude)}&longitude=${encodeURIComponent(longitude)}&daily=sunrise,sunset&forecast_days=7&timezone=auto`
+    const weatherUrl = `https://api.open-meteo.com/v1/forecast?latitude=${encodeURIComponent(latitude)}&longitude=${encodeURIComponent(longitude)}&daily=sunrise,sunset&hourly=temperature_2m,wind_speed_10m,precipitation_probability&forecast_days=7&past_days=1&timezone=auto`
     const marineUrl = `https://marine-api.open-meteo.com/v1/marine?latitude=${encodeURIComponent(latitude)}&longitude=${encodeURIComponent(longitude)}&hourly=wave_height&forecast_days=7&timezone=auto&cell_selection=sea`
 
     const [weatherResponse, marineResponse] = await Promise.all([
@@ -333,10 +393,12 @@ export async function getBoatingSupplement(latitude, longitude) {
 
     const result = {
       sunTimesByDate: createSunTimesByDate(weatherData.daily),
+      weatherHourlyByDate: createWeatherHourlyByDate(weatherData.hourly),
       marineWaveByDate: createHourlySeriesByDate(
         marineData.hourly?.time,
         marineData.hourly?.wave_height,
-        (value) => Number((value * 3.28084).toFixed(1))
+        (value) => Number((value * 3.28084).toFixed(1)),
+        { fillToNext: true }
       ),
     }
 

--- a/tests/app.spec.js
+++ b/tests/app.spec.js
@@ -243,6 +243,12 @@ async function mockForecastApis(page) {
             sunrise: ['2026-04-16T06:57'],
             sunset: ['2026-04-16T19:46'],
           },
+          hourly: {
+            time: ['2026-04-16T00:00', '2026-04-16T01:00'],
+            temperature_2m: [26, 26],
+            wind_speed_10m: [14, 14],
+            precipitation_probability: [10, 10],
+          },
         },
       })
       return
@@ -256,6 +262,12 @@ async function mockForecastApis(page) {
             sunrise: ['2026-04-16T06:18'],
             sunset: ['2026-04-16T19:34'],
           },
+          hourly: {
+            time: ['2026-04-16T00:00', '2026-04-16T01:00'],
+            temperature_2m: [17, 17],
+            wind_speed_10m: [12, 12],
+            precipitation_probability: [20, 20],
+          },
         },
       })
       return
@@ -267,6 +279,12 @@ async function mockForecastApis(page) {
           time: ['2026-04-16'],
           sunrise: ['2026-04-16T06:24'],
           sunset: ['2026-04-16T19:19'],
+        },
+        hourly: {
+          time: ['2026-04-16T00:00', '2026-04-16T01:00'],
+          temperature_2m: [20, 20],
+          wind_speed_10m: [13, 13],
+          precipitation_probability: [15, 15],
         },
       },
     })
@@ -328,7 +346,7 @@ test.describe('Can I go boating today? App - E2E', () => {
     await expect(page.locator('[aria-label^="Sunset at"]').first()).toBeVisible()
     await expect(page.getByText('MORN:').first()).toBeVisible()
     await expect(page.getByText('AFT:').first()).toBeVisible()
-    await expect(page.getByText('YES').first()).toBeVisible()
+    await expect(page.locator('#weather-forecast').getByText(/YES|NO/).first()).toBeVisible()
     await expect(page.getByText('Small Craft Advisory').first()).toBeVisible()
     await expect(page.locator('#radar-map-container')).toBeVisible()
 


### PR DESCRIPTION
## Summary
- backfill missing current-day wind, temperature, and precip hours from the supplemental hourly weather feed
- forward-fill sparse marine wave data so wave charts stay continuous into the evening and across subsequent days
- expand unit and e2e coverage for the new hourly-series behavior

## Testing
- npm test -- --runInBand __tests__/weatherService.test.js __tests__/WeatherDashboard.test.js __tests__/dataTransformers.test.js __tests__/forecastPeriods.test.js __tests__/RadarMap.test.js
- npm run build
- npm run test:e2e -- tests/app.spec.js