### PR TITLE
Fix future-day wave forecasts and location fallback

### DIFF
--- a/__tests__/WeatherDashboard.test.js
+++ b/__tests__/WeatherDashboard.test.js
@@ -48,7 +48,7 @@ jest.mock('@/components/charts/HourlyCharts', () => ({
   ),
 }))
 
-const DASHBOARD_CACHE_KEY = 'weatherDashboard:v3:lastSuccessfulState'
+const DASHBOARD_CACHE_KEY = 'weatherDashboard:v4:lastSuccessfulState'
 
 function buildWeatherData() {
   return {
@@ -158,6 +158,10 @@ function buildSupplementData() {
     },
     weatherHourlyByDate: buildWeatherHourlySupplement(),
     marineWaveByDate: buildMarineGridData(),
+    marineWaveMaxByDate: {
+      '2026-04-16': 3.9,
+      '2026-04-17': 4.2,
+    },
   }
 }
 
@@ -496,6 +500,28 @@ describe('WeatherDashboard', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Wave Height (ft)' }))
     expect(screen.getByText('3.9 ft')).toBeInTheDocument()
+  })
+
+  test('keeps wave chart data available when switching to a future day', async () => {
+    mockGeolocationSuccess()
+    const weatherData = buildWeatherData()
+    weatherData.gridData.waveHeight.values = []
+    getNWSForecast.mockResolvedValue(weatherData)
+    getBoatingSupplement.mockResolvedValue(buildSupplementData())
+    getTideData.mockResolvedValue(buildTideData())
+    getNWSAlerts.mockResolvedValue(buildAlertsData())
+
+    render(<WeatherDashboard />)
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Thu' })).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByRole('heading', { name: 'Fri' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Wave Height (ft)' }))
+
+    expect(screen.getByRole('heading', { name: 'Friday' })).toBeInTheDocument()
+    expect(screen.getByText('4.2 ft')).toBeInTheDocument()
   })
 
   test('backs fills missing current-day wind hours from supplemental hourly weather data', async () => {

--- a/__tests__/weatherService.test.js
+++ b/__tests__/weatherService.test.js
@@ -6,7 +6,7 @@ global.fetch = jest.fn()
 describe('weatherService', () => {
   // Clear all mock implementations and call counts before each test
   beforeEach(() => {
-    fetch.mockClear()
+    fetch.mockReset()
     sessionStorage.clear()
     localStorage.clear()
   })
@@ -86,7 +86,7 @@ describe('weatherService', () => {
 
     test('returns cached forecast data without refetching', async () => {
       sessionStorage.setItem(
-        'forecast:v3:34.05,-118.24',
+        'forecast:v4:34.05,-118.24',
         JSON.stringify({
           timestamp: Date.now(),
           payload: { periods: [{ name: 'Cached Today' }], gridData: { cached: true } },
@@ -137,7 +137,7 @@ describe('weatherService', () => {
 
     test('refreshes stale point metadata and retries once when the forecast URL returns 404', async () => {
       sessionStorage.setItem(
-        'points:v3:34.05,-118.24',
+        'points:v4:34.05,-118.24',
         JSON.stringify({
           timestamp: Date.now(),
           payload: {
@@ -217,8 +217,12 @@ describe('weatherService', () => {
           ok: true,
           json: async () => ({
             hourly: {
-              time: ['2026-04-16T07:00', '2026-04-16T10:00', '2026-04-17T07:00'],
-              wave_height: [1.2, 1.4, 1.5],
+              time: ['2026-04-16T20:00', '2026-04-17T08:00'],
+              wave_height: [1.2, 1.5],
+            },
+            daily: {
+              time: ['2026-04-16', '2026-04-17'],
+              wave_height_max: [1.4, 1.6],
             },
           }),
         })
@@ -235,16 +239,21 @@ describe('weatherService', () => {
       expect(supplement.weatherHourlyByDate['2026-04-16'].wind[0]).toBe(8)
       expect(supplement.weatherHourlyByDate['2026-04-16'].wind[23]).toBe(8)
       expect(supplement.weatherHourlyByDate['2026-04-16'].precip[12]).toBe(15)
-      expect(supplement.marineWaveByDate['2026-04-16'][7]).toBe(3.9)
-      expect(supplement.marineWaveByDate['2026-04-16'][10]).toBe(4.6)
-      expect(supplement.marineWaveByDate['2026-04-16'][23]).toBe(4.6)
-      expect(supplement.marineWaveByDate['2026-04-17'][7]).toBe(4.9)
+      expect(supplement.marineWaveByDate['2026-04-16'][20]).toBe(3.9)
+      expect(supplement.marineWaveByDate['2026-04-16'][23]).toBe(3.9)
+      expect(supplement.marineWaveByDate['2026-04-17'][0]).toBe(3.9)
+      expect(supplement.marineWaveByDate['2026-04-17'][7]).toBe(3.9)
+      expect(supplement.marineWaveByDate['2026-04-17'][8]).toBe(4.9)
       expect(supplement.marineWaveByDate['2026-04-17'][23]).toBe(4.9)
+      expect(supplement.marineWaveMaxByDate).toEqual({
+        '2026-04-16': 4.6,
+        '2026-04-17': 5.2,
+      })
     })
 
     test('returns cached supplement data without refetching', async () => {
       sessionStorage.setItem(
-        'supplement:v3:34.05,-118.24',
+        'supplement:v4:34.05,-118.24',
         JSON.stringify({
           timestamp: Date.now(),
           payload: {
@@ -362,7 +371,7 @@ describe('weatherService', () => {
 
     test('returns cached alerts without refetching', async () => {
       sessionStorage.setItem(
-        'alerts:v3:34.05,-118.24',
+        'alerts:v4:34.05,-118.24',
         JSON.stringify({
           timestamp: Date.now(),
           payload: {
@@ -421,7 +430,7 @@ describe('weatherService', () => {
 
     test('returns cached tide data without refetching', async () => {
       sessionStorage.setItem(
-        'tideData:v3:34.05,-118.24',
+        'tideData:v4:34.05,-118.24',
         JSON.stringify({
           timestamp: Date.now(),
           payload: { predictions: [{ t: '2026-04-16 13:00', v: '1.9' }] },
@@ -444,7 +453,7 @@ describe('weatherService', () => {
   describe('geocodeLocation', () => {
     test('returns cached geocode results without refetching', async () => {
       localStorage.setItem(
-        'geocode:v3:san diego',
+        'geocode:v4:san diego',
         JSON.stringify({
           timestamp: Date.now(),
           payload: { name: 'San Diego', latitude: 32.7157, longitude: -117.1611 },

--- a/components/WeatherDashboard.js
+++ b/components/WeatherDashboard.js
@@ -2,7 +2,7 @@
 /* eslint-disable jsx-a11y/alt-text */
 'use client'
 
-import { useState, useEffect, useMemo } from 'react'
+import { useState, useEffect, useMemo, useRef } from 'react'
 import { geocodeLocation, getBoatingSupplement, getNWSAlerts, getNWSForecast, getTideData } from '@/lib/weatherService'
 import TideChart from './TideChart'
 import { extractHourlyDataForDay } from '@/lib/dataTransformers'
@@ -11,7 +11,7 @@ import DynamicRadarMap from './DynamicRadarMap'
 import { formatWeekdayLabel, getDailyForecastCards, getLocalDateKey } from '@/lib/forecastPeriods'
 import { parseWaveHeightValue } from '@/lib/forecastUtils'
 
-const DASHBOARD_CACHE_KEY = 'weatherDashboard:v3:lastSuccessfulState'
+const DASHBOARD_CACHE_KEY = 'weatherDashboard:v4:lastSuccessfulState'
 const DASHBOARD_CACHE_MAX_AGE_MS = 30 * 60 * 1000
 const GEOLOCATION_OPTIONS = {
   enableHighAccuracy: false,
@@ -306,6 +306,14 @@ export default function WeatherDashboard() {
   const [alertsStatus, setAlertsStatus] = useState('idle')
   const [activeChartHour, setActiveChartHour] = useState(null)
   const [shouldLoadRadar, setShouldLoadRadar] = useState(false)
+  const locationRequestTokenRef = useRef(0)
+
+  const beginLocationRequest = () => {
+    locationRequestTokenRef.current += 1
+    return locationRequestTokenRef.current
+  }
+
+  const isLatestLocationRequest = (requestToken) => locationRequestTokenRef.current === requestToken
 
   const clearActiveChartHour = () => {
     setActiveChartHour(null)
@@ -320,11 +328,14 @@ export default function WeatherDashboard() {
       return
     }
 
+    const requestToken = beginLocationRequest()
     setError(null)
     setLoading(true)
 
     requestCurrentLocation(
       (position) => {
+        if (!isLatestLocationRequest(requestToken)) return
+
         const { latitude, longitude } = position.coords
         const resolvedLocationName = `Latitude: ${latitude.toFixed(4)}, Longitude: ${longitude.toFixed(4)}`
         setLocation({ latitude, longitude })
@@ -332,6 +343,7 @@ export default function WeatherDashboard() {
         fetchData(latitude, longitude, resolvedLocationName)
       },
       (locationError) => {
+        if (!isLatestLocationRequest(requestToken)) return
         setError(getGeolocationErrorMessage(locationError))
         setLoading(false)
       }
@@ -387,14 +399,25 @@ export default function WeatherDashboard() {
     }
 
     if (navigator.geolocation) {
+      const requestToken = beginLocationRequest()
       requestCurrentLocation(
         (position) => {
+          if (!isLatestLocationRequest(requestToken)) return
+
           const { latitude, longitude } = position.coords
+          const resolvedLocationName = `Latitude: ${latitude.toFixed(4)}, Longitude: ${longitude.toFixed(4)}`
           setLocation({ latitude, longitude })
-          setLocationName(`Latitude: ${latitude.toFixed(4)}, Longitude: ${longitude.toFixed(4)}`)
-          fetchData(latitude, longitude, `Latitude: ${latitude.toFixed(4)}, Longitude: ${longitude.toFixed(4)}`)
+          setLocationName(resolvedLocationName)
+          fetchData(latitude, longitude, resolvedLocationName)
         },
         () => {
+          if (!isLatestLocationRequest(requestToken)) return
+
+          if (cachedDashboard) {
+            setLoading(false)
+            return
+          }
+
           // Default to New York if geolocation fails
           const defaultLat = 40.7128
           const defaultLon = -74.0060
@@ -515,15 +538,19 @@ export default function WeatherDashboard() {
     e.preventDefault()
     if (!locationInput) return
 
+    const requestToken = beginLocationRequest()
     setLoading(true)
     setError(null)
 
     try {
       const loc = await geocodeLocation(locationInput)
+      if (!isLatestLocationRequest(requestToken)) return
+
       setLocation({ latitude: loc.latitude, longitude: loc.longitude })
       setLocationName(loc.name)
       await fetchData(loc.latitude, loc.longitude, loc.name)
     } catch (err) {
+      if (!isLatestLocationRequest(requestToken)) return
       setError(err.message || 'Error geocoding location.')
       setLoading(false)
     }
@@ -587,13 +614,14 @@ export default function WeatherDashboard() {
     }
 
     const fallbackWaveValue =
+      weatherData?.marineWaveMaxByDate?.[selectedDateStr] ??
       parseWaveHeightValue(dailyCards[selectedDayIndex]?.detailedForecast)
     if (fallbackWaveValue === null) {
       return hasWaveSeriesData ? hourlyData.wave : hourlyData.wave.map(() => null)
     }
 
     return hourlyData.wave.map(() => fallbackWaveValue)
-  }, [dailyCards, hourlyData, selectedDayIndex])
+  }, [dailyCards, hourlyData, selectedDateStr, selectedDayIndex, weatherData?.marineWaveMaxByDate])
 
   const activeHourLabel = useMemo(() => {
     if (activeChartHour === null || activeChartHour === undefined || !hourlyData?.labels) return null

--- a/lib/weatherService.js
+++ b/lib/weatherService.js
@@ -10,7 +10,7 @@ import { error as logError } from "./logger.js";
 // The NWS API requires a unique User-Agent header for all requests.
 // This helps them identify the application making the request.
 const NWS_USER_AGENT = `CanIGoBoatingToday/1.0 (canigoboatingtoday.com, hello@canigoboatingtoday.com)`
-const CLIENT_CACHE_VERSION = 'v3'
+const CLIENT_CACHE_VERSION = 'v4'
 const FORECAST_CACHE_PREFIX = `forecast:${CLIENT_CACHE_VERSION}:`
 const POINTS_CACHE_PREFIX = `points:${CLIENT_CACHE_VERSION}:`
 const TIDE_DATA_CACHE_PREFIX = `tideData:${CLIENT_CACHE_VERSION}:`
@@ -206,51 +206,84 @@ async function loadForecastForCoordinates(latitude, longitude) {
 
 function createHourlySeriesByDate(times = [], values = [], transform = (value) => value, { fillToNext = false } = {}) {
   const result = {}
+  const ensureDateBucket = (dateKey) => {
+    if (!result[dateKey]) {
+      result[dateKey] = new Array(24).fill(null)
+    }
+  }
+  const getNextDateKey = (dateKey) => {
+    const nextDate = new Date(`${dateKey}T00:00:00`)
+    nextDate.setDate(nextDate.getDate() + 1)
+    return nextDate.toISOString().slice(0, 10)
+  }
   const parsedEntries = times
     .map((timeValue, index) => {
       if (typeof timeValue !== 'string') return null
 
-      const parsedDate = new Date(timeValue)
       const rawValue = values[index]
-      if (Number.isNaN(parsedDate.getTime()) || rawValue === null || rawValue === undefined) {
+      const dateKey = timeValue.slice(0, 10)
+      const hour = Number.parseInt(timeValue.slice(11, 13), 10)
+
+      if (!dateKey || !Number.isInteger(hour) || hour < 0 || hour > 23 || rawValue === null || rawValue === undefined) {
         return null
       }
 
       return {
-        parsedDate,
+        dateKey,
+        hour,
         rawValue,
       }
     })
     .filter(Boolean)
 
   parsedEntries.forEach((entry, index) => {
-    const dateKey = `${entry.parsedDate.getFullYear()}-${String(entry.parsedDate.getMonth() + 1).padStart(2, '0')}-${String(entry.parsedDate.getDate()).padStart(2, '0')}`
-    const hour = entry.parsedDate.getHours()
-
-    if (!result[dateKey]) {
-      result[dateKey] = new Array(24).fill(null)
-    }
+    ensureDateBucket(entry.dateKey)
 
     const transformedValue = transform(entry.rawValue)
-    result[dateKey][hour] = transformedValue
+    result[entry.dateKey][entry.hour] = transformedValue
 
     if (!fillToNext) {
       return
     }
 
     const nextEntry = parsedEntries[index + 1] ?? null
-    const nextDate = nextEntry ? nextEntry.parsedDate : null
-    const endHourExclusive =
-      nextDate && nextDate.toDateString() === entry.parsedDate.toDateString()
-        ? Math.min(24, nextDate.getHours())
-        : 24
+    if (!nextEntry) {
+      for (let fillHour = entry.hour + 1; fillHour < 24; fillHour += 1) {
+        result[entry.dateKey][fillHour] = transformedValue
+      }
+      return
+    }
 
-    for (let fillHour = hour + 1; fillHour < endHourExclusive; fillHour += 1) {
-      result[dateKey][fillHour] = transformedValue
+    let fillDateKey = entry.dateKey
+    let fillHour = entry.hour + 1
+
+    while (
+      fillDateKey < nextEntry.dateKey ||
+      (fillDateKey === nextEntry.dateKey && fillHour < nextEntry.hour)
+    ) {
+      if (fillHour === 24) {
+        fillDateKey = getNextDateKey(fillDateKey)
+        fillHour = 0
+      }
+
+      ensureDateBucket(fillDateKey)
+      result[fillDateKey][fillHour] = transformedValue
+      fillHour += 1
     }
   })
 
   return result
+}
+
+function createDailyValueByDate(dailyData = {}, propertyName, transform = (value) => value) {
+  const dates = dailyData.time ?? []
+  const values = dailyData[propertyName] ?? []
+
+  return dates.reduce((result, dateKey, index) => {
+    const rawValue = values[index]
+    result[dateKey] = rawValue === null || rawValue === undefined ? null : transform(rawValue)
+    return result
+  }, {})
 }
 
 function createWeatherHourlyByDate(hourlyData = {}) {
@@ -373,7 +406,7 @@ export async function getBoatingSupplement(latitude, longitude) {
     }
 
     const weatherUrl = `https://api.open-meteo.com/v1/forecast?latitude=${encodeURIComponent(latitude)}&longitude=${encodeURIComponent(longitude)}&daily=sunrise,sunset&hourly=temperature_2m,wind_speed_10m,precipitation_probability&forecast_days=7&past_days=1&timezone=auto`
-    const marineUrl = `https://marine-api.open-meteo.com/v1/marine?latitude=${encodeURIComponent(latitude)}&longitude=${encodeURIComponent(longitude)}&hourly=wave_height&forecast_days=7&timezone=auto&cell_selection=sea`
+    const marineUrl = `https://marine-api.open-meteo.com/v1/marine?latitude=${encodeURIComponent(latitude)}&longitude=${encodeURIComponent(longitude)}&hourly=wave_height&daily=wave_height_max&forecast_days=7&timezone=auto&cell_selection=sea`
 
     const [weatherResponse, marineResponse] = await Promise.all([
       fetchJsonWithTimeout(weatherUrl),
@@ -399,6 +432,11 @@ export async function getBoatingSupplement(latitude, longitude) {
         marineData.hourly?.wave_height,
         (value) => Number((value * 3.28084).toFixed(1)),
         { fillToNext: true }
+      ),
+      marineWaveMaxByDate: createDailyValueByDate(
+        marineData.daily,
+        'wave_height_max',
+        (value) => Number((value * 3.28084).toFixed(1))
       ),
     }
 

--- a/tests/app.spec.js
+++ b/tests/app.spec.js
@@ -300,6 +300,10 @@ async function mockForecastApis(page) {
             time: ['2026-04-16T07:00'],
             wave_height: [1.0],
           },
+          daily: {
+            time: ['2026-04-16'],
+            wave_height_max: [1.0],
+          },
         },
       })
       return
@@ -312,6 +316,10 @@ async function mockForecastApis(page) {
             time: ['2026-04-16T07:00'],
             wave_height: [1.3],
           },
+          daily: {
+            time: ['2026-04-16'],
+            wave_height_max: [1.3],
+          },
         },
       })
       return
@@ -322,6 +330,10 @@ async function mockForecastApis(page) {
         hourly: {
           time: ['2026-04-16T07:00'],
           wave_height: [1.2],
+        },
+        daily: {
+          time: ['2026-04-16'],
+          wave_height_max: [1.2],
         },
       },
     })


### PR DESCRIPTION
## Summary
- keep future-day wave charts populated by carrying marine readings across midnight and using daily marine wave maxima as a fallback
- bump client cache versions so browsers fetch the new supplement/dashboard payload shapes
- prevent stale geolocation callbacks from overriding a newer manual or current-location selection

## Testing
- npm test -- --runInBand __tests__/weatherService.test.js __tests__/WeatherDashboard.test.js __tests__/dataTransformers.test.js __tests__/forecastPeriods.test.js __tests__/RadarMap.test.js
- npm run build
- npm run test:e2e -- tests/app.spec.js