### PR TITLE
Speed up loading and remove New York fallback

### DIFF
--- a/__tests__/WeatherDashboard.test.js
+++ b/__tests__/WeatherDashboard.test.js
@@ -48,7 +48,19 @@ jest.mock('@/components/charts/HourlyCharts', () => ({
   ),
 }))
 
-const DASHBOARD_CACHE_KEY = 'weatherDashboard:v4:lastSuccessfulState'
+const DASHBOARD_CACHE_KEY = 'weatherDashboard:v5:lastSuccessfulState'
+
+function createDeferred() {
+  let resolve
+  let reject
+
+  const promise = new Promise((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+
+  return { promise, resolve, reject }
+}
 
 function buildWeatherData() {
   return {
@@ -331,19 +343,19 @@ describe('WeatherDashboard', () => {
     expect(rainIcon.style.filter).toContain('hue-rotate(176deg)')
   })
 
-  test('falls back to New York when geolocation is denied', async () => {
+  test('shows a location prompt instead of defaulting to New York when geolocation is denied', async () => {
     mockGeolocationError()
-    getNWSForecast.mockResolvedValue(buildWeatherData())
-    getTideData.mockResolvedValue(buildTideData())
-    getNWSAlerts.mockResolvedValue(buildAlertsData())
 
     render(<WeatherDashboard />)
 
     await waitFor(() =>
-      expect(getNWSForecast).toHaveBeenCalledWith(40.7128, -74.006)
+      expect(
+        screen.getByText('Unable to get your current location. Enter a location to continue.')
+      ).toBeInTheDocument()
     )
 
-    expect(screen.getByText('New York')).toBeInTheDocument()
+    expect(getNWSForecast).not.toHaveBeenCalled()
+    expect(screen.queryByText('New York')).not.toBeInTheDocument()
   })
 
   test('supports manual location searches', async () => {
@@ -395,6 +407,38 @@ describe('WeatherDashboard', () => {
         timeout: 8000,
         maximumAge: 300000,
       })
+    )
+  })
+
+  test('renders the main forecast before slower supplemental requests finish', async () => {
+    mockGeolocationSuccess()
+    const supplementDeferred = createDeferred()
+    const tideDeferred = createDeferred()
+    const alertsDeferred = createDeferred()
+
+    getNWSForecast.mockResolvedValue(buildWeatherData())
+    getBoatingSupplement.mockReturnValue(supplementDeferred.promise)
+    getTideData.mockReturnValue(tideDeferred.promise)
+    getNWSAlerts.mockReturnValue(alertsDeferred.promise)
+
+    render(<WeatherDashboard />)
+
+    await waitFor(() =>
+      expect(screen.getByRole('heading', { name: 'Thu' })).toBeInTheDocument()
+    )
+
+    expect(screen.getByRole('button', { name: 'Wind Speed (mph)' })).toBeInTheDocument()
+    expect(screen.getByText('Loading tide chart...')).toBeInTheDocument()
+
+    await act(async () => {
+      supplementDeferred.resolve(buildSupplementData())
+      tideDeferred.resolve(buildTideData())
+      alertsDeferred.resolve(buildAlertsData())
+      await Promise.resolve()
+    })
+
+    await waitFor(() =>
+      expect(screen.queryByText('Loading tide chart...')).not.toBeInTheDocument()
     )
   })
 

--- a/__tests__/weatherService.test.js
+++ b/__tests__/weatherService.test.js
@@ -86,7 +86,7 @@ describe('weatherService', () => {
 
     test('returns cached forecast data without refetching', async () => {
       sessionStorage.setItem(
-        'forecast:v4:34.05,-118.24',
+        'forecast:v5:34.05,-118.24',
         JSON.stringify({
           timestamp: Date.now(),
           payload: { periods: [{ name: 'Cached Today' }], gridData: { cached: true } },
@@ -137,7 +137,7 @@ describe('weatherService', () => {
 
     test('refreshes stale point metadata and retries once when the forecast URL returns 404', async () => {
       sessionStorage.setItem(
-        'points:v4:34.05,-118.24',
+        'points:v5:34.05,-118.24',
         JSON.stringify({
           timestamp: Date.now(),
           payload: {
@@ -253,7 +253,7 @@ describe('weatherService', () => {
 
     test('returns cached supplement data without refetching', async () => {
       sessionStorage.setItem(
-        'supplement:v4:34.05,-118.24',
+        'supplement:v5:34.05,-118.24',
         JSON.stringify({
           timestamp: Date.now(),
           payload: {
@@ -371,7 +371,7 @@ describe('weatherService', () => {
 
     test('returns cached alerts without refetching', async () => {
       sessionStorage.setItem(
-        'alerts:v4:34.05,-118.24',
+        'alerts:v5:34.05,-118.24',
         JSON.stringify({
           timestamp: Date.now(),
           payload: {
@@ -430,7 +430,7 @@ describe('weatherService', () => {
 
     test('returns cached tide data without refetching', async () => {
       sessionStorage.setItem(
-        'tideData:v4:34.05,-118.24',
+        'tideData:v5:34.05,-118.24',
         JSON.stringify({
           timestamp: Date.now(),
           payload: { predictions: [{ t: '2026-04-16 13:00', v: '1.9' }] },
@@ -453,7 +453,7 @@ describe('weatherService', () => {
   describe('geocodeLocation', () => {
     test('returns cached geocode results without refetching', async () => {
       localStorage.setItem(
-        'geocode:v4:san diego',
+        'geocode:v5:san diego',
         JSON.stringify({
           timestamp: Date.now(),
           payload: { name: 'San Diego', latitude: 32.7157, longitude: -117.1611 },

--- a/components/WeatherDashboard.js
+++ b/components/WeatherDashboard.js
@@ -11,7 +11,7 @@ import DynamicRadarMap from './DynamicRadarMap'
 import { formatWeekdayLabel, getDailyForecastCards, getLocalDateKey } from '@/lib/forecastPeriods'
 import { parseWaveHeightValue } from '@/lib/forecastUtils'
 
-const DASHBOARD_CACHE_KEY = 'weatherDashboard:v4:lastSuccessfulState'
+const DASHBOARD_CACHE_KEY = 'weatherDashboard:v5:lastSuccessfulState'
 const DASHBOARD_CACHE_MAX_AGE_MS = 30 * 60 * 1000
 const GEOLOCATION_OPTIONS = {
   enableHighAccuracy: false,
@@ -189,6 +189,10 @@ function getGeolocationErrorMessage(error) {
   return 'Unable to get your current location.'
 }
 
+function getGeolocationRecoveryMessage(error) {
+  return `${getGeolocationErrorMessage(error)} Enter a location to continue.`
+}
+
 function formatSunTime(dateInput) {
   if (!dateInput) return '--:--'
 
@@ -307,6 +311,7 @@ export default function WeatherDashboard() {
   const [activeChartHour, setActiveChartHour] = useState(null)
   const [shouldLoadRadar, setShouldLoadRadar] = useState(false)
   const locationRequestTokenRef = useRef(0)
+  const dataRequestTokenRef = useRef(0)
 
   const beginLocationRequest = () => {
     locationRequestTokenRef.current += 1
@@ -314,6 +319,11 @@ export default function WeatherDashboard() {
   }
 
   const isLatestLocationRequest = (requestToken) => locationRequestTokenRef.current === requestToken
+  const beginDataRequest = () => {
+    dataRequestTokenRef.current += 1
+    return dataRequestTokenRef.current
+  }
+  const isLatestDataRequest = (requestToken) => dataRequestTokenRef.current === requestToken
 
   const clearActiveChartHour = () => {
     setActiveChartHour(null)
@@ -344,7 +354,7 @@ export default function WeatherDashboard() {
       },
       (locationError) => {
         if (!isLatestLocationRequest(requestToken)) return
-        setError(getGeolocationErrorMessage(locationError))
+        setError(getGeolocationRecoveryMessage(locationError))
         setLoading(false)
       }
     )
@@ -418,24 +428,23 @@ export default function WeatherDashboard() {
             return
           }
 
-          // Default to New York if geolocation fails
-          const defaultLat = 40.7128
-          const defaultLon = -74.0060
-          setLocation({ latitude: defaultLat, longitude: defaultLon })
-          setLocationName(`New York`)
-          fetchData(defaultLat, defaultLon, 'New York')
+          setLoading(false)
+          setError(getGeolocationRecoveryMessage())
         }
       )
     } else {
-      const defaultLat = 40.7128
-      const defaultLon = -74.0060
-      setLocation({ latitude: defaultLat, longitude: defaultLon })
-      setLocationName(`New York`)
-      fetchData(defaultLat, defaultLon, 'New York')
+      if (cachedDashboard) {
+        setLoading(false)
+        return
+      }
+
+      setLoading(false)
+      setError('Current location is not available in this browser. Enter a location to continue.')
     }
   }, [])
 
   const fetchData = async (latitude, longitude, resolvedLocationName = locationName) => {
+    const dataRequestToken = beginDataRequest()
     const previousState = {
       location,
       locationName,
@@ -452,68 +461,71 @@ export default function WeatherDashboard() {
       setTideStatus('loading')
       setAlertsStatus('loading')
 
-      const forecastPromise = getNWSForecast(latitude, longitude)
-      const supplementPromise = getBoatingSupplement(latitude, longitude).catch((supplementError) => ({
-        error: supplementError,
-      }))
-      const tidePromise = getTideData(latitude, longitude).catch((tideError) => ({
-        error: tideError,
-      }))
-      const alertsPromise = getNWSAlerts(latitude, longitude).catch((alertsError) => ({
-        error: alertsError,
-      }))
+      const forecast = await getNWSForecast(latitude, longitude)
+      if (!isLatestDataRequest(dataRequestToken)) return
 
-      const forecast = await forecastPromise
       setWeatherData(forecast)
       setSelectedDayIndex(0)
       setActiveChartHour(null)
       setLoading(false)
 
-      const [supplementResult, tideResult, alertsResult] = await Promise.all([
-        supplementPromise,
-        tidePromise,
-        alertsPromise,
-      ])
-      const enrichedForecast = !supplementResult?.error
-        ? {
-            ...forecast,
-            ...supplementResult,
-          }
-        : forecast
+      void (async () => {
+        const [supplementResult, tideResult, alertsResult] = await Promise.all([
+          getBoatingSupplement(latitude, longitude).catch((supplementError) => ({
+            error: supplementError,
+          })),
+          getTideData(latitude, longitude).catch((tideError) => ({
+            error: tideError,
+          })),
+          getNWSAlerts(latitude, longitude).catch((alertsError) => ({
+            error: alertsError,
+          })),
+        ])
+        if (!isLatestDataRequest(dataRequestToken)) return
 
-      if (!supplementResult?.error) {
-        setWeatherData(enrichedForecast)
-      }
+        const enrichedForecast = !supplementResult?.error
+          ? {
+              ...forecast,
+              ...supplementResult,
+            }
+          : forecast
 
-      if (!tideResult?.error) {
-        const tides = tideResult
-        setTideData(tides)
-        setTideStatus('ready')
-        cacheDashboardState({
-          location: { latitude, longitude },
-          locationName: resolvedLocationName,
-          weatherData: enrichedForecast,
-          tideData: tides,
-          tideStatus: 'ready',
-        })
-      } else {
-        setTideStatus('error')
-        cacheDashboardState({
-          location: { latitude, longitude },
-          locationName: resolvedLocationName,
-          weatherData: enrichedForecast,
-          tideData: null,
-          tideStatus: 'error',
-        })
-      }
+        if (!supplementResult?.error) {
+          setWeatherData(enrichedForecast)
+        }
 
-      if (!alertsResult?.error) {
-        setAlertsData(alertsResult)
-        setAlertsStatus('ready')
-      } else {
-        setAlertsStatus('error')
-      }
+        if (!tideResult?.error) {
+          const tides = tideResult
+          setTideData(tides)
+          setTideStatus('ready')
+          cacheDashboardState({
+            location: { latitude, longitude },
+            locationName: resolvedLocationName,
+            weatherData: enrichedForecast,
+            tideData: tides,
+            tideStatus: 'ready',
+          })
+        } else {
+          setTideStatus('error')
+          cacheDashboardState({
+            location: { latitude, longitude },
+            locationName: resolvedLocationName,
+            weatherData: enrichedForecast,
+            tideData: null,
+            tideStatus: 'error',
+          })
+        }
+
+        if (!alertsResult?.error) {
+          setAlertsData(alertsResult)
+          setAlertsStatus('ready')
+        } else {
+          setAlertsStatus('error')
+        }
+      })()
     } catch (err) {
+      if (!isLatestDataRequest(dataRequestToken)) return
+
       if (previousState.weatherData || previousState.tideData || previousState.alertsData) {
         setLocation(previousState.location)
         setLocationName(previousState.locationName)

--- a/lib/weatherService.js
+++ b/lib/weatherService.js
@@ -10,7 +10,7 @@ import { error as logError } from "./logger.js";
 // The NWS API requires a unique User-Agent header for all requests.
 // This helps them identify the application making the request.
 const NWS_USER_AGENT = `CanIGoBoatingToday/1.0 (canigoboatingtoday.com, hello@canigoboatingtoday.com)`
-const CLIENT_CACHE_VERSION = 'v4'
+const CLIENT_CACHE_VERSION = 'v5'
 const FORECAST_CACHE_PREFIX = `forecast:${CLIENT_CACHE_VERSION}:`
 const POINTS_CACHE_PREFIX = `points:${CLIENT_CACHE_VERSION}:`
 const TIDE_DATA_CACHE_PREFIX = `tideData:${CLIENT_CACHE_VERSION}:`

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -27,7 +27,18 @@ try {
     runtimeCaching: defaultRuntimeCaching,
   } = await import('@ducanh2912/next-pwa')
 
-  const runtimeCaching = defaultRuntimeCaching.map((entry) => {
+  const weatherApiRuntimeCaching = [
+    {
+      urlPattern:
+        /^https:\/\/(?:api\.weather\.gov|api\.open-meteo\.com|geocoding-api\.open-meteo\.com|marine-api\.open-meteo\.com|api\.tidesandcurrents\.noaa\.gov)\/.*/i,
+      handler: 'NetworkOnly',
+      method: 'GET',
+    },
+  ]
+
+  const runtimeCaching = [
+    ...weatherApiRuntimeCaching,
+    ...defaultRuntimeCaching.map((entry) => {
     const cacheName = entry.options?.cacheName
 
     if (cacheName === 'next-static-js-assets' || cacheName === 'static-js-assets') {
@@ -42,7 +53,8 @@ try {
     }
 
     return entry
-  })
+  }),
+  ]
 
   withPWA = withPWAInit({
     ...pwaConfig,

--- a/tests/app.spec.js
+++ b/tests/app.spec.js
@@ -370,7 +370,7 @@ test.describe('Can I go boating today? App - E2E', () => {
     )
   })
 
-  test('falls back to New York when browser geolocation fails', async ({ page }) => {
+  test('shows a location prompt when browser geolocation fails', async ({ page }) => {
     await page.addInitScript(() => {
       Object.defineProperty(window.navigator, 'geolocation', {
         configurable: true,
@@ -382,8 +382,10 @@ test.describe('Can I go boating today? App - E2E', () => {
 
     await page.goto('/')
 
-    await expect(page.getByText('New York')).toBeVisible({ timeout: 15000 })
-    await expect(page.locator('#charts-container .chart-container')).toHaveCount(5, { timeout: 15000 })
+    await expect(
+      page.getByText('Unable to get your current location. Enter a location to continue.')
+    ).toBeVisible({ timeout: 15000 })
+    await expect(page.getByText('New York')).toHaveCount(0)
   })
 
   test('supports searching for a different location manually', async ({ page }) => {


### PR DESCRIPTION
## Summary
- render the main forecast first, then load supplement, tide, and alerts in the background for faster perceived loading
- stop the service worker from proxying weather and geocoding APIs to avoid Workbox no-response failures
- remove the silent New York fallback and show a clear location prompt when geolocation is unavailable

## Testing
- npm test -- --runInBand __tests__/WeatherDashboard.test.js __tests__/weatherService.test.js __tests__/forecastPeriods.test.js __tests__/RadarMap.test.js __tests__/dataTransformers.test.js
- npm run build
- npm run test:e2e -- tests/app.spec.js