### PR TITLE
Handle forecast timeouts more gracefully

### DIFF
--- a/__tests__/WeatherDashboard.test.js
+++ b/__tests__/WeatherDashboard.test.js
@@ -499,6 +499,35 @@ describe('WeatherDashboard', () => {
     expect(screen.getByRole('heading', { name: 'Thu' })).toBeInTheDocument()
   })
 
+  test('keeps the cached dashboard visible if a refresh forecast times out', async () => {
+    mockGeolocationSuccess()
+    localStorage.setItem(
+      DASHBOARD_CACHE_KEY,
+      JSON.stringify({
+        timestamp: Date.now(),
+        payload: {
+          location: { latitude: 32.7157, longitude: -117.1611 },
+          locationName: 'San Diego',
+          weatherData: buildWeatherData(),
+          tideData: buildTideData(),
+          tideStatus: 'ready',
+        },
+      })
+    )
+    getNWSForecast.mockRejectedValue(new Error('Request timed out after 8 seconds.'))
+
+    render(<WeatherDashboard />)
+
+    await waitFor(() =>
+      expect(
+        screen.getByText('Failed to fetch data: Request timed out after 8 seconds.')
+      ).toBeInTheDocument()
+    )
+
+    expect(screen.getByText('San Diego')).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Thu' })).toBeInTheDocument()
+  })
+
   test('shows an old-style boating day card with hi low sun times and concise decisions', async () => {
     mockGeolocationSuccess()
     const weatherData = buildWeatherData()

--- a/__tests__/weatherService.test.js
+++ b/__tests__/weatherService.test.js
@@ -135,6 +135,27 @@ describe('weatherService', () => {
       )
     })
 
+    test('returns the forecast even when the grid data request times out', async () => {
+      fetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => mockPointsData,
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => mockForecastData,
+        })
+        .mockRejectedValueOnce(new Error('Request timed out after 5 seconds.'))
+
+      const forecast = await getNWSForecast(latitude, longitude)
+
+      expect(forecast).toEqual({
+        ...mockForecastData.properties,
+        gridData: null,
+        radarStation: 'KSOX',
+      })
+    })
+
     test('refreshes stale point metadata and retries once when the forecast URL returns 404', async () => {
       sessionStorage.setItem(
         'points:v5:34.05,-118.24',

--- a/components/WeatherDashboard.js
+++ b/components/WeatherDashboard.js
@@ -312,6 +312,7 @@ export default function WeatherDashboard() {
   const [shouldLoadRadar, setShouldLoadRadar] = useState(false)
   const locationRequestTokenRef = useRef(0)
   const dataRequestTokenRef = useRef(0)
+  const lastSuccessfulStateRef = useRef(null)
 
   const beginLocationRequest = () => {
     locationRequestTokenRef.current += 1
@@ -395,6 +396,15 @@ export default function WeatherDashboard() {
   useEffect(() => {
     const cachedDashboard = getCachedDashboardState()
     if (cachedDashboard) {
+      lastSuccessfulStateRef.current = {
+        location: cachedDashboard.location ?? null,
+        locationName: cachedDashboard.locationName ?? '',
+        weatherData: cachedDashboard.weatherData ?? null,
+        tideData: cachedDashboard.tideData ?? null,
+        alertsData: null,
+        tideStatus: cachedDashboard.tideStatus ?? 'idle',
+        alertsStatus: 'idle',
+      }
       setLocation(cachedDashboard.location ?? null)
       setWeatherData(cachedDashboard.weatherData ?? null)
       setTideData(cachedDashboard.tideData ?? null)
@@ -445,7 +455,7 @@ export default function WeatherDashboard() {
 
   const fetchData = async (latitude, longitude, resolvedLocationName = locationName) => {
     const dataRequestToken = beginDataRequest()
-    const previousState = {
+    const previousState = lastSuccessfulStateRef.current ?? {
       location,
       locationName,
       weatherData,
@@ -468,6 +478,15 @@ export default function WeatherDashboard() {
       setSelectedDayIndex(0)
       setActiveChartHour(null)
       setLoading(false)
+      lastSuccessfulStateRef.current = {
+        location: { latitude, longitude },
+        locationName: resolvedLocationName,
+        weatherData: forecast,
+        tideData: previousState.tideData ?? null,
+        alertsData: previousState.alertsData ?? null,
+        tideStatus: previousState.tideStatus ?? 'idle',
+        alertsStatus: previousState.alertsStatus ?? 'idle',
+      }
 
       void (async () => {
         const [supplementResult, tideResult, alertsResult] = await Promise.all([
@@ -521,6 +540,16 @@ export default function WeatherDashboard() {
           setAlertsStatus('ready')
         } else {
           setAlertsStatus('error')
+        }
+
+        lastSuccessfulStateRef.current = {
+          location: { latitude, longitude },
+          locationName: resolvedLocationName,
+          weatherData: enrichedForecast,
+          tideData: !tideResult?.error ? tideResult : null,
+          alertsData: !alertsResult?.error ? alertsResult : null,
+          tideStatus: !tideResult?.error ? 'ready' : 'error',
+          alertsStatus: !alertsResult?.error ? 'ready' : 'error',
         }
       })()
     } catch (err) {
@@ -850,7 +879,7 @@ export default function WeatherDashboard() {
                         <span className="text-white/80">/</span>
                         <span className="min text-[0.9em] text-white/85">{card.temperatureLow ?? '--'}&deg;{temperatureUnit}</span>
                     </div>
-                    <div className="mt-6 grid grid-cols-2 gap-3 text-center">
+                    <div className="mt-4 grid grid-cols-2 gap-3 text-center">
                       <div
                         aria-label={`Sunrise at ${sunriseLabel}`}
                         className="flex items-center justify-center gap-2 whitespace-nowrap text-white/95"
@@ -878,7 +907,7 @@ export default function WeatherDashboard() {
                         <span className="text-[1.02em] font-semibold tabular-nums">{sunsetLabel}</span>
                       </div>
                     </div>
-                    <div className="mt-6 space-y-3">
+                    <div className="mt-4 space-y-2">
                       {dayDecisions.map((decision) => (
                         <div
                           key={decision.key}

--- a/lib/weatherService.js
+++ b/lib/weatherService.js
@@ -24,6 +24,9 @@ const GEOCODE_CACHE_DURATION_MS = 24 * 60 * 60 * 1000
 const ALERTS_CACHE_DURATION_MS = 5 * 60 * 1000
 const SUPPLEMENT_CACHE_DURATION_MS = 30 * 60 * 1000
 const DEFAULT_FETCH_TIMEOUT_MS = 8000
+const NWS_POINTS_TIMEOUT_MS = 12000
+const NWS_FORECAST_TIMEOUT_MS = 12000
+const NWS_GRID_DATA_TIMEOUT_MS = 5000
 const NWS_HEADERS = {
   "User-Agent": NWS_USER_AGENT,
 }
@@ -134,7 +137,7 @@ async function getNWSPointMetadata(latitude, longitude, { forceRefresh = false }
   const pointsUrl = `https://api.weather.gov/points/${encodeURIComponent(latitude)},${encodeURIComponent(longitude)}`
   const pointsResponse = await fetchJsonWithTimeout(pointsUrl, {
     headers: NWS_HEADERS,
-  })
+  }, NWS_POINTS_TIMEOUT_MS)
 
   if (!pointsResponse.ok) {
     const error = new Error(
@@ -157,12 +160,29 @@ async function fetchForecastFromPointMetadata(pointsData) {
     throw new Error("Could not retrieve forecast URL from NWS points data.")
   }
 
-  const requests = [fetchJsonWithTimeout(forecastUrl, { headers: NWS_HEADERS })]
-  if (gridDataUrl) {
-    requests.push(fetchJsonWithTimeout(gridDataUrl, { headers: NWS_HEADERS }))
-  }
+  const forecastResponsePromise = fetchJsonWithTimeout(
+    forecastUrl,
+    { headers: NWS_HEADERS },
+    NWS_FORECAST_TIMEOUT_MS
+  )
+  const gridDataPromise = gridDataUrl
+    ? fetchJsonWithTimeout(
+        gridDataUrl,
+        { headers: NWS_HEADERS },
+        NWS_GRID_DATA_TIMEOUT_MS
+      )
+        .then(async (response) => {
+          if (!response.ok) return null
+          const data = await response.json()
+          return data?.properties ?? null
+        })
+        .catch((error) => {
+          logError("NWS grid data request failed:", error)
+          return null
+        })
+    : Promise.resolve(null)
 
-  const [forecastResponse, gridDataResponse] = await Promise.all(requests)
+  const forecastResponse = await forecastResponsePromise
 
   if (!forecastResponse.ok) {
     const error = new Error(
@@ -173,11 +193,11 @@ async function fetchForecastFromPointMetadata(pointsData) {
   }
 
   const forecastData = await forecastResponse.json()
-  const gridData = gridDataResponse?.ok ? await gridDataResponse.json() : null
+  const gridData = await gridDataPromise
 
   return {
     ...forecastData.properties,
-    gridData: gridData ? gridData.properties : null,
+    gridData,
     radarStation: pointsData.properties?.radarStation ?? null,
   }
 }


### PR DESCRIPTION
## Summary
- make the NWS forecast path tolerate slow grid-data responses instead of failing the whole page
- keep the last good dashboard visible if a later refresh times out
- tighten the spacing between sunrise/sunset and the MORN/AFT rows in the day cards

## Testing
- npm test -- --runInBand __tests__/weatherService.test.js __tests__/WeatherDashboard.test.js
- npm run build