### PR TITLE
Speed up forecast loading and startup fallback

### DIFF
--- a/__tests__/WeatherDashboard.test.js
+++ b/__tests__/WeatherDashboard.test.js
@@ -49,6 +49,7 @@ jest.mock('@/components/charts/HourlyCharts', () => ({
 }))
 
 const DASHBOARD_CACHE_KEY = 'weatherDashboard:v5:lastSuccessfulState'
+const LAST_LOCATION_CACHE_KEY = 'weatherDashboard:v1:lastLocation'
 
 function createDeferred() {
   let resolve
@@ -273,12 +274,12 @@ describe('WeatherDashboard', () => {
   })
 
   test('renders initial layout properly', () => {
-    const { container } = render(<WeatherDashboard />)
+    render(<WeatherDashboard />)
 
     expect(screen.getByText('Can I go boating today?')).toBeInTheDocument()
     expect(screen.getByPlaceholderText('Enter a location')).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Use current location' })).toBeInTheDocument()
-    expect(container.querySelector('#loader-overlay')).toBeInTheDocument()
+    expect(document.querySelector('#loader-overlay')).not.toBeInTheDocument()
   })
 
   test('shows an offline message when the browser is offline', () => {
@@ -343,19 +344,21 @@ describe('WeatherDashboard', () => {
     expect(rainIcon.style.filter).toContain('hue-rotate(176deg)')
   })
 
-  test('shows a location prompt instead of defaulting to New York when geolocation is denied', async () => {
+  test('keeps manual location entry available instead of defaulting to New York when startup geolocation fails', async () => {
     mockGeolocationError()
 
     render(<WeatherDashboard />)
 
     await waitFor(() =>
-      expect(
-        screen.getByText('Unable to get your current location. Enter a location to continue.')
-      ).toBeInTheDocument()
+      expect(window.navigator.geolocation.getCurrentPosition).toHaveBeenCalled()
     )
 
     expect(getNWSForecast).not.toHaveBeenCalled()
     expect(screen.queryByText('New York')).not.toBeInTheDocument()
+    expect(
+      screen.queryByText('Unable to get your current location. Enter a location to continue.')
+    ).not.toBeInTheDocument()
+    expect(screen.getByPlaceholderText('Enter a location')).toBeInTheDocument()
   })
 
   test('supports manual location searches', async () => {
@@ -404,10 +407,38 @@ describe('WeatherDashboard', () => {
       expect.any(Function),
       expect.any(Function),
       expect.objectContaining({
-        timeout: 8000,
-        maximumAge: 300000,
+        timeout: 20000,
+        maximumAge: 900000,
       })
     )
+  })
+
+  test('falls back to the last viewed location when startup geolocation times out', async () => {
+    mockGeolocationError()
+    localStorage.setItem(
+      LAST_LOCATION_CACHE_KEY,
+      JSON.stringify({
+        timestamp: Date.now(),
+        payload: {
+          location: { latitude: 26.9298, longitude: -82.0454 },
+          locationName: 'Punta Gorda',
+        },
+      })
+    )
+    getNWSForecast.mockResolvedValue(buildWeatherData())
+    getTideData.mockResolvedValue(buildTideData())
+    getNWSAlerts.mockResolvedValue(buildAlertsData())
+
+    render(<WeatherDashboard />)
+
+    await waitFor(() =>
+      expect(getNWSForecast).toHaveBeenCalledWith(26.9298, -82.0454)
+    )
+
+    expect(screen.getByText('Punta Gorda')).toBeInTheDocument()
+    expect(
+      screen.queryByText('Unable to get your current location. Enter a location to continue.')
+    ).not.toBeInTheDocument()
   })
 
   test('renders the main forecast before slower supplemental requests finish', async () => {

--- a/__tests__/weatherService.test.js
+++ b/__tests__/weatherService.test.js
@@ -38,24 +38,54 @@ describe('weatherService', () => {
         periods: [{ name: 'Today', detailedForecast: 'Sunny.' }],
       },
     }
+    const mockFastForecastData = {
+      daily: {
+        time: ['2026-04-16'],
+        weather_code: [0],
+        temperature_2m_max: [22],
+        temperature_2m_min: [17],
+        precipitation_probability_max: [10],
+        wind_speed_10m_max: [14],
+      },
+      hourly: {
+        time: ['2026-04-16T00:00', '2026-04-16T01:00'],
+        temperature_2m: [20, 21],
+        wind_speed_10m: [10, 11],
+        precipitation_probability: [5, 10],
+      },
+    }
+    const buildOkResponse = (body) => ({
+      ok: true,
+      json: async () => body,
+    })
+    const buildErrorResponse = (statusText, status) => ({
+      ok: false,
+      statusText,
+      status,
+    })
+    const isFastForecastRequest = (url) =>
+      String(url).startsWith('https://api.open-meteo.com/v1/forecast?')
 
     test('successfully fetches and returns forecast data', async () => {
-      // Set up the mock chain for fetch
-      fetch
-        // First call for gridpoints
-        .mockResolvedValueOnce({
-          ok: true,
-          json: async () => mockPointsData,
-        })
-        // Second & Third calls for forecast & gridData (Promise.all)
-        .mockResolvedValueOnce({
-          ok: true,
-          json: async () => mockForecastData,
-        })
-        .mockResolvedValueOnce({
-          ok: true,
-          json: async () => ({ properties: { testGrid: true } }),
-        })
+      fetch.mockImplementation(async (url) => {
+        if (isFastForecastRequest(url)) {
+          throw new Error('Fast forecast unavailable')
+        }
+
+        if (url === `https://api.weather.gov/points/${latitude},${longitude}`) {
+          return buildOkResponse(mockPointsData)
+        }
+
+        if (url === mockPointsData.properties.forecast) {
+          return buildOkResponse(mockForecastData)
+        }
+
+        if (url === mockPointsData.properties.forecastGridData) {
+          return buildOkResponse({ properties: { testGrid: true } })
+        }
+
+        throw new Error(`Unexpected fetch URL: ${url}`)
+      })
 
       const forecast = await getNWSForecast(latitude, longitude)
 
@@ -101,10 +131,16 @@ describe('weatherService', () => {
 
 
     test('throws an error if the points API request fails', async () => {
-      // Simulate a failed response from the points API
-      fetch.mockResolvedValueOnce({
-        ok: false,
-        statusText: 'Not Found',
+      fetch.mockImplementation(async (url) => {
+        if (isFastForecastRequest(url)) {
+          throw new Error('Fast forecast unavailable')
+        }
+
+        if (url === `https://api.weather.gov/points/${latitude},${longitude}`) {
+          return buildErrorResponse('Not Found')
+        }
+
+        throw new Error(`Unexpected fetch URL: ${url}`)
       })
 
       // Expect the function to reject with an error
@@ -114,20 +150,25 @@ describe('weatherService', () => {
     })
 
     test('throws an error if the forecast API request fails', async () => {
-      // Simulate a successful points request followed by a failed forecast request
-      fetch
-        .mockResolvedValueOnce({
-          ok: true,
-          json: async () => mockPointsData,
-        })
-        .mockResolvedValueOnce({
-          ok: false,
-          statusText: 'Internal Server Error',
-        })
-        .mockResolvedValueOnce({
-          ok: true,
-          json: async () => ({ properties: {} })
-        })
+      fetch.mockImplementation(async (url) => {
+        if (isFastForecastRequest(url)) {
+          throw new Error('Fast forecast unavailable')
+        }
+
+        if (url === `https://api.weather.gov/points/${latitude},${longitude}`) {
+          return buildOkResponse(mockPointsData)
+        }
+
+        if (url === mockPointsData.properties.forecast) {
+          return buildErrorResponse('Internal Server Error')
+        }
+
+        if (url === mockPointsData.properties.forecastGridData) {
+          return buildOkResponse({ properties: {} })
+        }
+
+        throw new Error(`Unexpected fetch URL: ${url}`)
+      })
 
       // Expect the function to reject with an error
       await expect(getNWSForecast(latitude, longitude)).rejects.toThrow(
@@ -136,16 +177,25 @@ describe('weatherService', () => {
     })
 
     test('returns the forecast even when the grid data request times out', async () => {
-      fetch
-        .mockResolvedValueOnce({
-          ok: true,
-          json: async () => mockPointsData,
-        })
-        .mockResolvedValueOnce({
-          ok: true,
-          json: async () => mockForecastData,
-        })
-        .mockRejectedValueOnce(new Error('Request timed out after 5 seconds.'))
+      fetch.mockImplementation(async (url) => {
+        if (isFastForecastRequest(url)) {
+          throw new Error('Fast forecast unavailable')
+        }
+
+        if (url === `https://api.weather.gov/points/${latitude},${longitude}`) {
+          return buildOkResponse(mockPointsData)
+        }
+
+        if (url === mockPointsData.properties.forecast) {
+          return buildOkResponse(mockForecastData)
+        }
+
+        if (url === mockPointsData.properties.forecastGridData) {
+          throw new Error('Request timed out after 5 seconds.')
+        }
+
+        throw new Error(`Unexpected fetch URL: ${url}`)
+      })
 
       const forecast = await getNWSForecast(latitude, longitude)
 
@@ -154,6 +204,33 @@ describe('weatherService', () => {
         gridData: null,
         radarStation: 'KSOX',
       })
+    })
+
+    test('returns a fast forecast fallback when the NWS request times out', async () => {
+      fetch.mockImplementation(async (url) => {
+        if (url === `https://api.weather.gov/points/${latitude},${longitude}`) {
+          throw new Error('Request timed out after 12 seconds.')
+        }
+
+        if (isFastForecastRequest(url)) {
+          return buildOkResponse(mockFastForecastData)
+        }
+
+        throw new Error(`Unexpected fetch URL: ${url}`)
+      })
+
+      const forecast = await getNWSForecast(latitude, longitude)
+
+      expect(forecast.periods[0]).toMatchObject({
+        name: 'Thursday',
+        shortForecast: 'Sunny',
+        temperature: 72,
+      })
+      expect(forecast.gridData.windSpeed.values[0]).toEqual({
+        validTime: '2026-04-16T00:00/PT1H',
+        value: 10,
+      })
+      expect(forecast.radarStation).toBeNull()
     })
 
     test('refreshes stale point metadata and retries once when the forecast URL returns 404', async () => {
@@ -171,28 +248,33 @@ describe('weatherService', () => {
         })
       )
 
-      fetch
-        .mockResolvedValueOnce({
-          ok: false,
-          status: 404,
-          statusText: 'Not Found',
-        })
-        .mockResolvedValueOnce({
-          ok: true,
-          json: async () => ({ properties: {} }),
-        })
-        .mockResolvedValueOnce({
-          ok: true,
-          json: async () => mockPointsData,
-        })
-        .mockResolvedValueOnce({
-          ok: true,
-          json: async () => mockForecastData,
-        })
-        .mockResolvedValueOnce({
-          ok: true,
-          json: async () => ({ properties: { refreshedGrid: true } }),
-        })
+      fetch.mockImplementation(async (url) => {
+        if (isFastForecastRequest(url)) {
+          throw new Error('Fast forecast unavailable')
+        }
+
+        if (url === 'https://api.weather.gov/gridpoints/OLD/1,1/forecast') {
+          return buildErrorResponse('Not Found', 404)
+        }
+
+        if (url === 'https://api.weather.gov/gridpoints/OLD/1,1') {
+          return buildOkResponse({ properties: {} })
+        }
+
+        if (url === `https://api.weather.gov/points/${latitude},${longitude}`) {
+          return buildOkResponse(mockPointsData)
+        }
+
+        if (url === mockPointsData.properties.forecast) {
+          return buildOkResponse(mockForecastData)
+        }
+
+        if (url === mockPointsData.properties.forecastGridData) {
+          return buildOkResponse({ properties: { refreshedGrid: true } })
+        }
+
+        throw new Error(`Unexpected fetch URL: ${url}`)
+      })
 
       const forecast = await getNWSForecast(latitude, longitude)
 
@@ -201,7 +283,7 @@ describe('weatherService', () => {
         gridData: { refreshedGrid: true },
         radarStation: 'KSOX',
       })
-      expect(fetch).toHaveBeenNthCalledWith(3, `https://api.weather.gov/points/${latitude},${longitude}`, expect.objectContaining({
+      expect(fetch).toHaveBeenCalledWith(`https://api.weather.gov/points/${latitude},${longitude}`, expect.objectContaining({
         headers: {
           'User-Agent': 'CanIGoBoatingToday/1.0 (canigoboatingtoday.com, hello@canigoboatingtoday.com)',
         },

--- a/components/WeatherDashboard.js
+++ b/components/WeatherDashboard.js
@@ -13,10 +13,12 @@ import { parseWaveHeightValue } from '@/lib/forecastUtils'
 
 const DASHBOARD_CACHE_KEY = 'weatherDashboard:v5:lastSuccessfulState'
 const DASHBOARD_CACHE_MAX_AGE_MS = 30 * 60 * 1000
+const LAST_LOCATION_CACHE_KEY = 'weatherDashboard:v1:lastLocation'
+const LAST_LOCATION_CACHE_MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000
 const GEOLOCATION_OPTIONS = {
   enableHighAccuracy: false,
-  timeout: 8000,
-  maximumAge: 5 * 60 * 1000,
+  timeout: 20000,
+  maximumAge: 15 * 60 * 1000,
 }
 const BOATING_WINDOWS = [
   { key: 'morning', label: 'AM', startHour: 6, endHour: 11 },
@@ -193,6 +195,41 @@ function getGeolocationRecoveryMessage(error) {
   return `${getGeolocationErrorMessage(error)} Enter a location to continue.`
 }
 
+function getCachedLastLocation() {
+  if (typeof window === 'undefined') return null
+
+  try {
+    const cachedValue = localStorage.getItem(LAST_LOCATION_CACHE_KEY)
+    if (!cachedValue) return null
+
+    const parsed = JSON.parse(cachedValue)
+    if (Date.now() - parsed.timestamp > LAST_LOCATION_CACHE_MAX_AGE_MS) {
+      localStorage.removeItem(LAST_LOCATION_CACHE_KEY)
+      return null
+    }
+
+    return parsed.payload ?? null
+  } catch {
+    return null
+  }
+}
+
+function cacheLastLocation(payload) {
+  if (typeof window === 'undefined' || !payload?.location) return
+
+  try {
+    localStorage.setItem(
+      LAST_LOCATION_CACHE_KEY,
+      JSON.stringify({
+        timestamp: Date.now(),
+        payload,
+      })
+    )
+  } catch {
+    // Ignore cache write errors.
+  }
+}
+
 function formatSunTime(dateInput) {
   if (!dateInput) return '--:--'
 
@@ -300,7 +337,7 @@ export default function WeatherDashboard() {
   const [weatherData, setWeatherData] = useState(null)
   const [tideData, setTideData] = useState(null)
   const [alertsData, setAlertsData] = useState(null)
-  const [loading, setLoading] = useState(true)
+  const [loading, setLoading] = useState(false)
   const [error, setError] = useState(null)
   const [isOffline, setIsOffline] = useState(false)
   const [locationName, setLocationName] = useState('')
@@ -341,7 +378,6 @@ export default function WeatherDashboard() {
 
     const requestToken = beginLocationRequest()
     setError(null)
-    setLoading(true)
 
     requestCurrentLocation(
       (position) => {
@@ -395,6 +431,7 @@ export default function WeatherDashboard() {
 
   useEffect(() => {
     const cachedDashboard = getCachedDashboardState()
+    const cachedLastLocation = getCachedLastLocation()
     if (cachedDashboard) {
       lastSuccessfulStateRef.current = {
         location: cachedDashboard.location ?? null,
@@ -438,8 +475,19 @@ export default function WeatherDashboard() {
             return
           }
 
+          if (cachedLastLocation?.location) {
+            const fallbackLocationName = cachedLastLocation.locationName ?? 'Last viewed location'
+            setLocation(cachedLastLocation.location)
+            setLocationName(fallbackLocationName)
+            fetchData(
+              cachedLastLocation.location.latitude,
+              cachedLastLocation.location.longitude,
+              fallbackLocationName
+            )
+            return
+          }
+
           setLoading(false)
-          setError(getGeolocationRecoveryMessage())
         }
       )
     } else {
@@ -448,8 +496,19 @@ export default function WeatherDashboard() {
         return
       }
 
+      if (cachedLastLocation?.location) {
+        const fallbackLocationName = cachedLastLocation.locationName ?? 'Last viewed location'
+        setLocation(cachedLastLocation.location)
+        setLocationName(fallbackLocationName)
+        fetchData(
+          cachedLastLocation.location.latitude,
+          cachedLastLocation.location.longitude,
+          fallbackLocationName
+        )
+        return
+      }
+
       setLoading(false)
-      setError('Current location is not available in this browser. Enter a location to continue.')
     }
   }, [])
 
@@ -487,6 +546,10 @@ export default function WeatherDashboard() {
         tideStatus: previousState.tideStatus ?? 'idle',
         alertsStatus: previousState.alertsStatus ?? 'idle',
       }
+      cacheLastLocation({
+        location: { latitude, longitude },
+        locationName: resolvedLocationName,
+      })
 
       void (async () => {
         const [supplementResult, tideResult, alertsResult] = await Promise.all([
@@ -551,6 +614,10 @@ export default function WeatherDashboard() {
           tideStatus: !tideResult?.error ? 'ready' : 'error',
           alertsStatus: !alertsResult?.error ? 'ready' : 'error',
         }
+        cacheLastLocation({
+          location: { latitude, longitude },
+          locationName: resolvedLocationName,
+        })
       })()
     } catch (err) {
       if (!isLatestDataRequest(dataRequestToken)) return
@@ -580,7 +647,6 @@ export default function WeatherDashboard() {
     if (!locationInput) return
 
     const requestToken = beginLocationRequest()
-    setLoading(true)
     setError(null)
 
     try {

--- a/lib/weatherService.js
+++ b/lib/weatherService.js
@@ -12,6 +12,7 @@ import { error as logError } from "./logger.js";
 const NWS_USER_AGENT = `CanIGoBoatingToday/1.0 (canigoboatingtoday.com, hello@canigoboatingtoday.com)`
 const CLIENT_CACHE_VERSION = 'v5'
 const FORECAST_CACHE_PREFIX = `forecast:${CLIENT_CACHE_VERSION}:`
+const FAST_FORECAST_CACHE_PREFIX = `fastForecast:${CLIENT_CACHE_VERSION}:`
 const POINTS_CACHE_PREFIX = `points:${CLIENT_CACHE_VERSION}:`
 const TIDE_DATA_CACHE_PREFIX = `tideData:${CLIENT_CACHE_VERSION}:`
 const GEOCODE_CACHE_PREFIX = `geocode:${CLIENT_CACHE_VERSION}:`
@@ -24,6 +25,7 @@ const GEOCODE_CACHE_DURATION_MS = 24 * 60 * 60 * 1000
 const ALERTS_CACHE_DURATION_MS = 5 * 60 * 1000
 const SUPPLEMENT_CACHE_DURATION_MS = 30 * 60 * 1000
 const DEFAULT_FETCH_TIMEOUT_MS = 8000
+const FAST_FORECAST_TIMEOUT_MS = 5000
 const NWS_POINTS_TIMEOUT_MS = 12000
 const NWS_FORECAST_TIMEOUT_MS = 12000
 const NWS_GRID_DATA_TIMEOUT_MS = 5000
@@ -68,6 +70,36 @@ const MARINE_ZONE_PREFIXES = [
   'PSZ',
   'SLZ',
 ]
+const OPEN_METEO_WEATHER_CODE_LABELS = {
+  0: 'Sunny',
+  1: 'Mostly Sunny',
+  2: 'Partly Sunny',
+  3: 'Cloudy',
+  45: 'Foggy',
+  48: 'Foggy',
+  51: 'Light Drizzle',
+  53: 'Drizzle',
+  55: 'Heavy Drizzle',
+  56: 'Freezing Drizzle',
+  57: 'Freezing Drizzle',
+  61: 'Light Rain',
+  63: 'Rain',
+  65: 'Heavy Rain',
+  66: 'Freezing Rain',
+  67: 'Freezing Rain',
+  71: 'Light Snow',
+  73: 'Snow',
+  75: 'Heavy Snow',
+  77: 'Snow',
+  80: 'Rain Showers',
+  81: 'Rain Showers',
+  82: 'Heavy Rain Showers',
+  85: 'Snow Showers',
+  86: 'Heavy Snow Showers',
+  95: 'Thunderstorms',
+  96: 'Thunderstorms',
+  99: 'Severe Thunderstorms',
+}
 
 function buildCoordinateCacheKey(prefix, latitude, longitude) {
   return `${prefix}${latitude.toFixed(2)},${longitude.toFixed(2)}`
@@ -354,6 +386,164 @@ function createSunTimesByDate(dailyData = {}) {
   }, {})
 }
 
+function getOpenMeteoShortForecast(weatherCode, precipitationProbability, windSpeed) {
+  if (precipitationProbability !== null && precipitationProbability !== undefined && precipitationProbability >= 65) {
+    return weatherCode >= 95 ? 'Thunderstorms' : 'Rain Likely'
+  }
+
+  if (windSpeed !== null && windSpeed !== undefined && windSpeed >= 32) {
+    return 'Breezy'
+  }
+
+  return OPEN_METEO_WEATHER_CODE_LABELS[weatherCode] ?? 'Partly Sunny'
+}
+
+function getOpenMeteoNightShortForecast(dayShortForecast) {
+  if (!dayShortForecast) return 'Mostly Clear'
+  if (dayShortForecast.includes('Thunder')) return dayShortForecast
+  if (dayShortForecast.includes('Rain') || dayShortForecast.includes('Drizzle')) return dayShortForecast
+  if (dayShortForecast.includes('Snow')) return dayShortForecast
+  if (dayShortForecast.includes('Fog')) return dayShortForecast
+  if (dayShortForecast.includes('Sunny')) return 'Mostly Clear'
+  return dayShortForecast
+}
+
+function buildDetailedForecast(shortForecast, temperature, windSpeed, precipitationProbability) {
+  const details = []
+
+  if (temperature !== null && temperature !== undefined) {
+    details.push(`High near ${Math.round(temperature)}.`)
+  }
+  if (windSpeed !== null && windSpeed !== undefined) {
+    details.push(`Wind up to ${Math.round(windSpeed * 0.621371)} mph.`)
+  }
+  if (precipitationProbability !== null && precipitationProbability !== undefined && precipitationProbability > 15) {
+    details.push(`Chance of rain ${Math.round(precipitationProbability)}%.`)
+  }
+
+  return [shortForecast, ...details].join(' ')
+}
+
+function buildOvernightForecast(shortForecast, lowTemperature) {
+  if (lowTemperature === null || lowTemperature === undefined) {
+    return shortForecast
+  }
+
+  return `${shortForecast}. Low around ${Math.round(lowTemperature)}.`
+}
+
+function createGridSeriesFromHourly(times = [], values = []) {
+  return times.reduce((result, timeValue, index) => {
+    const value = values[index]
+    if (typeof timeValue !== 'string' || value === null || value === undefined) {
+      return result
+    }
+
+    result.push({
+      validTime: `${timeValue}/PT1H`,
+      value,
+    })
+    return result
+  }, [])
+}
+
+function buildFastForecastFromOpenMeteo(data = {}) {
+  const daily = data.daily ?? {}
+  const hourly = data.hourly ?? {}
+  const dates = daily.time ?? []
+
+  const periods = dates.flatMap((dateKey, index) => {
+    const dayShortForecast = getOpenMeteoShortForecast(
+      daily.weather_code?.[index],
+      daily.precipitation_probability_max?.[index] ?? null,
+      daily.wind_speed_10m_max?.[index] ?? null
+    )
+    const nightShortForecast = getOpenMeteoNightShortForecast(dayShortForecast)
+    const weekdayLabel = new Intl.DateTimeFormat('en-US', { weekday: 'long' }).format(new Date(`${dateKey}T12:00:00`))
+    const temperatureMax = daily.temperature_2m_max?.[index] ?? null
+    const temperatureMin = daily.temperature_2m_min?.[index] ?? null
+
+    return [
+      {
+        name: weekdayLabel,
+        isDaytime: true,
+        temperature: temperatureMax !== null && temperatureMax !== undefined ? Math.round(temperatureMax * 9/5 + 32) : null,
+        temperatureUnit: 'F',
+        shortForecast: dayShortForecast,
+        detailedForecast: buildDetailedForecast(
+          dayShortForecast,
+          temperatureMax !== null && temperatureMax !== undefined ? temperatureMax * 9/5 + 32 : null,
+          daily.wind_speed_10m_max?.[index] ?? null,
+          daily.precipitation_probability_max?.[index] ?? null
+        ),
+        startTime: `${dateKey}T06:00:00`,
+      },
+      {
+        name: `${weekdayLabel} Night`,
+        isDaytime: false,
+        temperature: temperatureMin !== null && temperatureMin !== undefined ? Math.round(temperatureMin * 9/5 + 32) : null,
+        temperatureUnit: 'F',
+        shortForecast: nightShortForecast,
+        detailedForecast: buildOvernightForecast(
+          nightShortForecast,
+          temperatureMin !== null && temperatureMin !== undefined ? temperatureMin * 9/5 + 32 : null
+        ),
+        startTime: `${dateKey}T18:00:00`,
+      },
+    ]
+  })
+
+  return {
+    periods,
+    gridData: {
+      temperature: {
+        values: createGridSeriesFromHourly(hourly.time, hourly.temperature_2m),
+      },
+      windSpeed: {
+        values: createGridSeriesFromHourly(hourly.time, hourly.wind_speed_10m),
+      },
+      probabilityOfPrecipitation: {
+        values: createGridSeriesFromHourly(hourly.time, hourly.precipitation_probability),
+      },
+      waveHeight: {
+        values: [],
+      },
+    },
+    radarStation: null,
+  }
+}
+
+async function getFastForecast(latitude, longitude) {
+  const cacheKey = buildCoordinateCacheKey(FAST_FORECAST_CACHE_PREFIX, latitude, longitude)
+  const cachedForecast = getCachedApiPayload(cacheKey, FORECAST_CACHE_DURATION_MS)
+  if (cachedForecast) {
+    return cachedForecast
+  }
+
+  const response = await fetchJsonWithTimeout(
+    `https://api.open-meteo.com/v1/forecast?latitude=${encodeURIComponent(latitude)}&longitude=${encodeURIComponent(longitude)}&daily=weather_code,temperature_2m_max,temperature_2m_min,precipitation_probability_max,wind_speed_10m_max&hourly=temperature_2m,wind_speed_10m,precipitation_probability&forecast_days=7&past_days=1&timezone=auto`,
+    {},
+    FAST_FORECAST_TIMEOUT_MS
+  )
+
+  if (!response.ok) {
+    throw new Error(`Fast forecast API request failed: ${response.statusText}`)
+  }
+
+  const data = await response.json()
+  const forecast = buildFastForecastFromOpenMeteo(data)
+  cacheApiPayload(cacheKey, forecast)
+  return forecast
+}
+
+function unwrapForecastError(error) {
+  if (error instanceof AggregateError && Array.isArray(error.errors) && error.errors.length > 0) {
+    return error.errors[0]
+  }
+
+  return error
+}
+
 export async function geocodeLocation(query) {
   const trimmedQuery = String(query ?? '').trim()
   if (!trimmedQuery) {
@@ -403,13 +593,34 @@ export async function getNWSForecast(latitude, longitude) {
       return cachedForecast
     }
 
-    const result = await loadForecastForCoordinates(latitude, longitude)
-    cacheApiPayload(cacheKey, result)
-    return result
+    const nwsForecastPromise = loadForecastForCoordinates(latitude, longitude)
+      .then((result) => {
+        cacheApiPayload(cacheKey, result)
+        return { source: 'nws', forecast: result }
+      })
+
+    const fastForecastPromise = getFastForecast(latitude, longitude).then((result) => ({
+      source: 'fast',
+      forecast: result,
+    }))
+
+    const { source, forecast } = await Promise.any([
+      nwsForecastPromise,
+      fastForecastPromise,
+    ])
+
+    cacheApiPayload(cacheKey, forecast)
+
+    if (source === 'fast') {
+      void nwsForecastPromise.catch(() => null)
+    }
+
+    return forecast
   } catch (error) {
-    logError("Error fetching NWS forecast:", error);
+    const resolvedError = unwrapForecastError(error)
+    logError("Error fetching NWS forecast:", resolvedError);
     // Re-throw the error to be handled by the calling component
-    throw error;
+    throw resolvedError;
   }
 }
 

--- a/tests/app.spec.js
+++ b/tests/app.spec.js
@@ -370,7 +370,7 @@ test.describe('Can I go boating today? App - E2E', () => {
     )
   })
 
-  test('shows a location prompt when browser geolocation fails', async ({ page }) => {
+  test('keeps manual location entry available when browser geolocation fails', async ({ page }) => {
     await page.addInitScript(() => {
       Object.defineProperty(window.navigator, 'geolocation', {
         configurable: true,
@@ -382,10 +382,12 @@ test.describe('Can I go boating today? App - E2E', () => {
 
     await page.goto('/')
 
+    await expect(page.getByPlaceholder('Enter a location')).toBeVisible({ timeout: 15000 })
+    await expect(page.getByRole('button', { name: 'Get Weather' })).toBeVisible()
+    await expect(page.getByText('New York')).toHaveCount(0)
     await expect(
       page.getByText('Unable to get your current location. Enter a location to continue.')
-    ).toBeVisible({ timeout: 15000 })
-    await expect(page.getByText('New York')).toHaveCount(0)
+    ).toHaveCount(0)
   })
 
   test('supports searching for a different location manually', async ({ page }) => {


### PR DESCRIPTION
## Summary
- load a fast forecast fallback in parallel with NWS so location changes render quickly
- stop blocking initial render on geolocation and use the last viewed location as a fallback
- update unit and e2e coverage for the new startup and timeout behavior